### PR TITLE
Localization

### DIFF
--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -262,74 +262,6 @@
                 }
               }
             ]
-          },
-          {
-            "title": "Drive To Pose",
-            "x": 256.0,
-            "y": 384.0,
-            "width": 256.0,
-            "height": 384.0,
-            "type": "List Layout",
-            "properties": {
-              "label_position": "TOP"
-            },
-            "children": [
-              {
-                "title": "x",
-                "x": 0.0,
-                "y": 0.0,
-                "width": 128.0,
-                "height": 128.0,
-                "type": "Text Display",
-                "properties": {
-                  "topic": "/Shuffleboard/Swerve/OTFGx",
-                  "period": 0.06,
-                  "data_type": "double",
-                  "show_submit_button": false
-                }
-              },
-              {
-                "title": "y",
-                "x": 0.0,
-                "y": 0.0,
-                "width": 128.0,
-                "height": 128.0,
-                "type": "Text Display",
-                "properties": {
-                  "topic": "/Shuffleboard/Swerve/OTFGy",
-                  "period": 0.06,
-                  "data_type": "double",
-                  "show_submit_button": false
-                }
-              },
-              {
-                "title": "angle",
-                "x": 0.0,
-                "y": 0.0,
-                "width": 128.0,
-                "height": 128.0,
-                "type": "Text Display",
-                "properties": {
-                  "topic": "/Shuffleboard/Swerve/OTFGAngle",
-                  "period": 0.06,
-                  "data_type": "double",
-                  "show_submit_button": false
-                }
-              },
-              {
-                "title": "Drive To Pose",
-                "x": 768.0,
-                "y": 512.0,
-                "width": 384.0,
-                "height": 128.0,
-                "type": "Command",
-                "properties": {
-                  "topic": "/Shuffleboard/Swerve/Drive To Pose",
-                  "period": 0.06,
-                  "show_type": true
-                }
-              }
-            ]
           }
         ],
         "containers": [
@@ -370,10 +302,10 @@
           },
           {
             "title": "Field",
-            "x": 640.0,
-            "y": 384.0,
-            "width": 1024.0,
-            "height": 512.0,
+            "x": 768.0,
+            "y": 256.0,
+            "width": 768.0,
+            "height": 384.0,
             "type": "Field",
             "properties": {
               "topic": "/SmartDashboard/Field",
@@ -389,17 +321,27 @@
             }
           },
           {
-            "title": "X",
-            "x": 1024.0,
-            "y": 256.0,
-            "width": 128.0,
+            "title": "swerve info",
+            "x": 1152.0,
+            "y": 0.0,
+            "width": 256.0,
             "height": 128.0,
-            "type": "Text Display",
+            "type": "Subsystem",
             "properties": {
-              "topic": "/Shuffleboard/Swerve/X",
-              "period": 0.06,
-              "data_type": "double",
-              "show_submit_button": false
+              "topic": "/SmartDashboard/swerve info",
+              "period": 0.06
+            }
+          },
+          {
+            "title": "Command Scheduler",
+            "x": 512.0,
+            "y": 384.0,
+            "width": 256.0,
+            "height": 384.0,
+            "type": "Scheduler",
+            "properties": {
+              "topic": "/SmartDashboard/Command Scheduler",
+              "period": 0.06
             }
           }
         ]

--- a/src/main/deploy/pathplanner/autos/HeartAuto.auto
+++ b/src/main/deploy/pathplanner/autos/HeartAuto.auto
@@ -7,19 +7,7 @@
         {
           "type": "path",
           "data": {
-            "pathName": "testPath2"
-          }
-        },
-        {
-          "type": "named",
-          "data": {
-            "name": "print command"
-          }
-        },
-        {
-          "type": "path",
-          "data": {
-            "pathName": "testPath3"
+            "pathName": "HeartPath"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/autos/New Auto.auto
+++ b/src/main/deploy/pathplanner/autos/New Auto.auto
@@ -1,0 +1,55 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "path",
+          "data": {
+            "pathName": "C3B2"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "B2F"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "FB4"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "B4F"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "FB5"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "B5F"
+          }
+        },
+        {
+          "type": "path",
+          "data": {
+            "pathName": "FB6"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/autos/calibrationAuto.auto
+++ b/src/main/deploy/pathplanner/autos/calibrationAuto.auto
@@ -14,6 +14,6 @@
     }
   },
   "resetOdom": true,
-  "folder": "test and calibration paths",
+  "folder": "test and calibration autos",
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/calibrationAuto.auto
+++ b/src/main/deploy/pathplanner/autos/calibrationAuto.auto
@@ -14,6 +14,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "test and calibration paths",
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/testAuto.auto
+++ b/src/main/deploy/pathplanner/autos/testAuto.auto
@@ -27,6 +27,6 @@
     }
   },
   "resetOdom": true,
-  "folder": "test and calibration paths",
+  "folder": "test and calibration autos",
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/testAuto.auto
+++ b/src/main/deploy/pathplanner/autos/testAuto.auto
@@ -27,6 +27,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "test and calibration paths",
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/testAuto2.auto
+++ b/src/main/deploy/pathplanner/autos/testAuto2.auto
@@ -26,6 +26,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "test and calibration paths",
   "choreoAuto": false
 }

--- a/src/main/deploy/pathplanner/autos/testChoreoAuto.auto
+++ b/src/main/deploy/pathplanner/autos/testChoreoAuto.auto
@@ -14,6 +14,6 @@
     }
   },
   "resetOdom": true,
-  "folder": "test and calibration paths",
+  "folder": "test and calibration autos",
   "choreoAuto": true
 }

--- a/src/main/deploy/pathplanner/autos/testChoreoAuto.auto
+++ b/src/main/deploy/pathplanner/autos/testChoreoAuto.auto
@@ -14,6 +14,6 @@
     }
   },
   "resetOdom": true,
-  "folder": null,
+  "folder": "test and calibration paths",
   "choreoAuto": true
 }

--- a/src/main/deploy/pathplanner/autos/triggerTest.auto
+++ b/src/main/deploy/pathplanner/autos/triggerTest.auto
@@ -7,19 +7,7 @@
         {
           "type": "path",
           "data": {
-            "pathName": "testPath2"
-          }
-        },
-        {
-          "type": "named",
-          "data": {
-            "name": "print command"
-          }
-        },
-        {
-          "type": "path",
-          "data": {
-            "pathName": "testPath3"
+            "pathName": "trigger test"
           }
         }
       ]

--- a/src/main/deploy/pathplanner/paths/B2F.path
+++ b/src/main/deploy/pathplanner/paths/B2F.path
@@ -45,7 +45,7 @@
     "rotation": 54.0
   },
   "reversed": false,
-  "folder": "Elad",
+  "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 119.99999999999999

--- a/src/main/deploy/pathplanner/paths/B2F.path
+++ b/src/main/deploy/pathplanner/paths/B2F.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 5.266025641021306,
+        "y": 3.01358974359082
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 4.267458822464336,
+        "y": 2.3296316830859705
+      },
+      "isLocked": false,
+      "linkedName": "B2"
+    },
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": {
+        "x": 3.0398571466918525,
+        "y": 1.6997631722210356
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 119.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/B4F.path
+++ b/src/main/deploy/pathplanner/paths/B4F.path
@@ -45,7 +45,7 @@
     "rotation": 54.0
   },
   "reversed": false,
-  "folder": "Elad",
+  "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 59.99999999999999

--- a/src/main/deploy/pathplanner/paths/B4F.path
+++ b/src/main/deploy/pathplanner/paths/B4F.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 3.9966025641025635,
+        "y": 2.848461538461538
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 3.2556005509742323,
+        "y": 2.18036541732839
+      },
+      "isLocked": false,
+      "linkedName": "B4"
+    },
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": {
+        "x": 2.0573594267617046,
+        "y": 1.0001683932879848
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/B5F.path
+++ b/src/main/deploy/pathplanner/paths/B5F.path
@@ -45,7 +45,7 @@
     "rotation": 54.0
   },
   "reversed": false,
-  "folder": "Elad",
+  "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 59.99999999999999

--- a/src/main/deploy/pathplanner/paths/B5F.path
+++ b/src/main/deploy/pathplanner/paths/B5F.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 3.7385897435897437,
+        "y": 3.044551282051282
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 3.0625779729651215,
+        "y": 2.2797021318723973
+      },
+      "isLocked": false,
+      "linkedName": "B5"
+    },
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": {
+        "x": 2.02605750709336,
+        "y": 1.0854428395427196
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/C3B1.path
+++ b/src/main/deploy/pathplanner/paths/C3B1.path
@@ -3,29 +3,29 @@
   "waypoints": [
     {
       "anchor": {
-        "x": 1.6538461538461533,
-        "y": 0.6605128205128199
+        "x": 7.980320512816177,
+        "y": 3.3851282051292815
       },
       "prevControl": null,
       "nextControl": {
-        "x": 2.3214093909274682,
-        "y": 1.2884963390571298
+        "x": 7.288731467033868,
+        "y": 3.5370129524923617
       },
       "isLocked": false,
-      "linkedName": "FEEDER"
+      "linkedName": "C3"
     },
     {
       "anchor": {
-        "x": 3.9966025641025635,
-        "y": 2.848461538461538
+        "x": 5.763404605263157,
+        "y": 3.8710526315789475
       },
       "prevControl": {
-        "x": 3.5075350504075242,
-        "y": 2.3761690063958025
+        "x": 6.5593005286612245,
+        "y": 3.6949205339623883
       },
       "nextControl": null,
       "isLocked": false,
-      "linkedName": "B4"
+      "linkedName": "c1"
     }
   ],
   "rotationTargets": [],
@@ -42,13 +42,13 @@
   },
   "goalEndState": {
     "velocity": 0,
-    "rotation": 59.99999999999999
+    "rotation": 180.0
   },
   "reversed": false,
   "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 54.0
+    "rotation": 180.0
   },
   "useDefaultConstraints": true
 }

--- a/src/main/deploy/pathplanner/paths/C3B2.path
+++ b/src/main/deploy/pathplanner/paths/C3B2.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 7.980320512816177,
+        "y": 3.3851282051292815
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 6.89643265855329,
+        "y": 3.3007264071430793
+      },
+      "isLocked": false,
+      "linkedName": "C3"
+    },
+    {
+      "anchor": {
+        "x": 5.266025641021306,
+        "y": 3.01358974359082
+      },
+      "prevControl": {
+        "x": 5.922131704066772,
+        "y": 3.096152002290731
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "B2"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 119.99999999999999
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 90.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/C3B2.path
+++ b/src/main/deploy/pathplanner/paths/C3B2.path
@@ -45,10 +45,10 @@
     "rotation": 119.99999999999999
   },
   "reversed": false,
-  "folder": "Elad",
+  "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
-    "rotation": 90.0
+    "rotation": 180.0
   },
   "useDefaultConstraints": true
 }

--- a/src/main/deploy/pathplanner/paths/C3L1F.path
+++ b/src/main/deploy/pathplanner/paths/C3L1F.path
@@ -1,0 +1,93 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 7.980320512816177,
+        "y": 3.3851282051292815
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 7.168174342105263,
+        "y": 4.150082236842105
+      },
+      "isLocked": false,
+      "linkedName": "C3"
+    },
+    {
+      "anchor": {
+        "x": 5.099506578947368,
+        "y": 2.8126644736842104
+      },
+      "prevControl": {
+        "x": 5.966262468981516,
+        "y": 3.3652213535809796
+      },
+      "nextControl": {
+        "x": 4.329769736842105,
+        "y": 2.3219572368421058
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": {
+        "x": 3.281003289473684,
+        "y": 1.9563322368421052
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 0.7496977025392991,
+      "rotationDegrees": 119.99999999999999
+    },
+    {
+      "waypointRelativePos": 1.3,
+      "rotationDegrees": 119.99999999999999
+    }
+  ],
+  "constraintZones": [
+    {
+      "name": "Constraints Zone",
+      "minWaypointRelativePos": 0.748663101604278,
+      "maxWaypointRelativePos": 1.2994652406417142,
+      "constraints": {
+        "maxVelocity": 3.0,
+        "maxAcceleration": 9.0,
+        "maxAngularVelocity": 658.9,
+        "maxAngularAcceleration": 720.0,
+        "nominalVoltage": 12.0,
+        "unlimited": false
+      }
+    }
+  ],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "reversed": false,
+  "folder": "CompPaths",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/FB4.path
+++ b/src/main/deploy/pathplanner/paths/FB4.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.3214093909274682,
+        "y": 1.2884963390571298
+      },
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    },
+    {
+      "anchor": {
+        "x": 3.9966025641025635,
+        "y": 2.848461538461538
+      },
+      "prevControl": {
+        "x": 3.5075350504075242,
+        "y": 2.3761690063958025
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "B4"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/FB5.path
+++ b/src/main/deploy/pathplanner/paths/FB5.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.5469215368394305,
+        "y": 1.6751270050786093
+      },
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    },
+    {
+      "anchor": {
+        "x": 3.7385897435897437,
+        "y": 3.044551282051282
+      },
+      "prevControl": {
+        "x": 3.418618282050262,
+        "y": 2.691083418540514
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "B5"
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 59.99999999999999
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/FB5.path
+++ b/src/main/deploy/pathplanner/paths/FB5.path
@@ -45,7 +45,7 @@
     "rotation": 59.99999999999999
   },
   "reversed": false,
-  "folder": "Elad",
+  "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 54.0

--- a/src/main/deploy/pathplanner/paths/FB6.path
+++ b/src/main/deploy/pathplanner/paths/FB6.path
@@ -1,0 +1,59 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 1.6538461538461533,
+        "y": 0.6605128205128199
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 2.139499098012099,
+        "y": 1.4843619083735673
+      },
+      "isLocked": false,
+      "linkedName": "FEEDER"
+    },
+    {
+      "anchor": {
+        "x": 3.2535256410256403,
+        "y": 3.8598717948717947
+      },
+      "prevControl": {
+        "x": 2.9296690463587627,
+        "y": 3.206811662630572
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": "B6"
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 0.661403508771944,
+      "rotationDegrees": 0.0
+    }
+  ],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "reversed": false,
+  "folder": "Elad",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 54.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/FB6.path
+++ b/src/main/deploy/pathplanner/paths/FB6.path
@@ -50,7 +50,7 @@
     "rotation": 0.0
   },
   "reversed": false,
-  "folder": "Elad",
+  "folder": "CompPaths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 54.0

--- a/src/main/deploy/pathplanner/paths/HeartPath.path
+++ b/src/main/deploy/pathplanner/paths/HeartPath.path
@@ -1,0 +1,109 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 2.644615384615384,
+        "y": 1.5996794871794873
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 1.9944230769230762,
+        "y": 2.2808333333333324
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 1.7983333333333331,
+        "y": 2.5904487179487172
+      },
+      "prevControl": {
+        "x": 1.7912475056626682,
+        "y": 2.292843955780794
+      },
+      "nextControl": {
+        "x": 1.8499358974358968,
+        "y": 4.757756410256409
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 2.582692307692307,
+        "y": 2.74525641025641
+      },
+      "prevControl": {
+        "x": 2.4382051282051274,
+        "y": 2.0331410256410254
+      },
+      "nextControl": {
+        "x": 2.7705667801983376,
+        "y": 3.671209167607561
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 3.717948717948717,
+        "y": 2.6110897435897438
+      },
+      "prevControl": {
+        "x": 4.337179487179486,
+        "y": 3.6844230769230766
+      },
+      "nextControl": {
+        "x": 3.0629396311025268,
+        "y": 1.475740659723014
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 2.644615384615384,
+        "y": 1.6203205128205127
+      },
+      "prevControl": {
+        "x": 3.163221153846152,
+        "y": 1.4190705128205128
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [
+    {
+      "name": "testTrigger",
+      "waypointRelativePos": 1.0,
+      "endWaypointRelativePos": 3.0,
+      "command": null
+    }
+  ],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "reversed": false,
+  "folder": "test and calibration paths",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/calibrationPath.path
+++ b/src/main/deploy/pathplanner/paths/calibrationPath.path
@@ -45,7 +45,7 @@
     "rotation": 0.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "test and calibration paths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 0.0

--- a/src/main/deploy/pathplanner/paths/testPath.path
+++ b/src/main/deploy/pathplanner/paths/testPath.path
@@ -66,7 +66,7 @@
     "rotation": 180.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "test and calibration paths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 0.0

--- a/src/main/deploy/pathplanner/paths/testPath2.path
+++ b/src/main/deploy/pathplanner/paths/testPath2.path
@@ -54,7 +54,7 @@
     "rotation": 0.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "test and calibration paths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 90.0

--- a/src/main/deploy/pathplanner/paths/testPath3.path
+++ b/src/main/deploy/pathplanner/paths/testPath3.path
@@ -45,7 +45,7 @@
     "rotation": -90.0
   },
   "reversed": false,
-  "folder": null,
+  "folder": "test and calibration paths",
   "idealStartingState": {
     "velocity": 0,
     "rotation": 0.0

--- a/src/main/deploy/pathplanner/paths/trigger test.path
+++ b/src/main/deploy/pathplanner/paths/trigger test.path
@@ -1,0 +1,61 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 0.0,
+        "y": 0.0
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 1.0,
+        "y": 0.0
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 3.0,
+        "y": 0.0
+      },
+      "prevControl": {
+        "x": 2.0,
+        "y": 1.2246467991473532e-16
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [
+    {
+      "name": "testTrigger",
+      "waypointRelativePos": 0.666666,
+      "endWaypointRelativePos": 1.0,
+      "command": null
+    }
+  ],
+  "globalConstraints": {
+    "maxVelocity": 4.45,
+    "maxAcceleration": 9.0,
+    "maxAngularVelocity": 658.9,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "reversed": false,
+  "folder": "test and calibration paths",
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 0.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/settings.json
+++ b/src/main/deploy/pathplanner/settings.json
@@ -3,7 +3,7 @@
   "robotLength": 0.67,
   "holonomicMode": true,
   "pathFolders": [
-    "Elad",
+    "CompPaths",
     "test and calibration paths"
   ],
   "autoFolders": [

--- a/src/main/deploy/pathplanner/settings.json
+++ b/src/main/deploy/pathplanner/settings.json
@@ -7,7 +7,7 @@
     "test and calibration paths"
   ],
   "autoFolders": [
-    "test and calibration paths"
+    "test and calibration autos"
   ],
   "defaultMaxVel": 4.45,
   "defaultMaxAccel": 9.0,

--- a/src/main/deploy/pathplanner/settings.json
+++ b/src/main/deploy/pathplanner/settings.json
@@ -2,8 +2,12 @@
   "robotWidth": 0.67,
   "robotLength": 0.67,
   "holonomicMode": true,
-  "pathFolders": [],
-  "autoFolders": [],
+  "pathFolders": [
+    "test and calibration paths"
+  ],
+  "autoFolders": [
+    "test and calibration paths"
+  ],
   "defaultMaxVel": 4.45,
   "defaultMaxAccel": 9.0,
   "defaultMaxAngVel": 658.9,

--- a/src/main/deploy/pathplanner/settings.json
+++ b/src/main/deploy/pathplanner/settings.json
@@ -3,6 +3,7 @@
   "robotLength": 0.67,
   "holonomicMode": true,
   "pathFolders": [
+    "Elad",
     "test and calibration paths"
   ],
   "autoFolders": [

--- a/src/main/java/frc/AuroraClient.java
+++ b/src/main/java/frc/AuroraClient.java
@@ -1,0 +1,66 @@
+package frc;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.networktables.*;
+
+public class AuroraClient {
+    private final NetworkTableInstance instance;
+    private final NetworkTable table;
+    private final NetworkTableEntry xEntry, yEntry, zEntry, rollEntry, pitchEntry, yawEntry;
+
+    public AuroraClient(NetworkTableInstance instance) {
+        this.instance = instance;
+        table = instance.getTable("Aurora/Localization");
+        xEntry = table.getEntry("X");
+        yEntry = table.getEntry("Y");
+        zEntry = table.getEntry("Z");
+        rollEntry = table.getEntry("Roll");
+        pitchEntry = table.getEntry("Pitch");
+        yawEntry = table.getEntry("Yaw");
+    }
+
+
+    public Pose3d getPose() {
+        Pose3d pose = new Pose3d(
+                xEntry.getDouble(-1),
+                yEntry.getDouble(-1),
+                zEntry.getDouble(-1),
+                new Rotation3d(
+                        rollEntry.getDouble(100),
+                        pitchEntry.getDouble(100),
+                        yawEntry.getDouble(100)));
+
+        if (pose.getX() == -1 ||
+                pose.getY() == -1 ||
+                pose.getZ() == -1 ||
+                pose.getRotation().getX() == 100 ||
+                pose.getRotation().getY() == 100 ||
+                pose.getRotation().getZ() == 100) return null;
+        return pose;
+    }
+
+    public double getX () {
+        if (xEntry==null) System.out.println("yehuda");
+        return xEntry.getDouble(-1);
+    }
+
+    public double getY () {
+        return yEntry.getDouble(-1);
+    }
+
+    public double getZ () {
+        return zEntry.getDouble(-1);
+    }
+    public double getRoll () {
+        return rollEntry.getDouble(100);
+    }
+
+    public double getPitch () {
+        return pitchEntry.getDouble(100);
+    }
+
+    public double getYaw () {
+        return yawEntry.getDouble(100);
+    }
+}

--- a/src/main/java/frc/excalib/additional_utilities/Elastic.java
+++ b/src/main/java/frc/excalib/additional_utilities/Elastic.java
@@ -1,0 +1,390 @@
+// Copyright (c) 2023-2025 Gold87 and other Elastic contributors
+// This software can be modified and/or shared under the terms
+// defined by the Elastic license:
+// https://github.com/Gold872/elastic-dashboard/blob/main/LICENSE
+
+package frc.excalib.additional_utilities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.networktables.StringPublisher;
+import edu.wpi.first.networktables.StringTopic;
+
+public final class Elastic {
+    private static final StringTopic notificationTopic =
+            NetworkTableInstance.getDefault().getStringTopic("/Elastic/RobotNotifications");
+    private static final StringPublisher notificationPublisher =
+            notificationTopic.publish(PubSubOption.sendAll(true), PubSubOption.keepDuplicates(true));
+    private static final StringTopic selectedTabTopic =
+            NetworkTableInstance.getDefault().getStringTopic("/Elastic/SelectedTab");
+    private static final StringPublisher selectedTabPublisher =
+            selectedTabTopic.publish(PubSubOption.keepDuplicates(true));
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Sends an notification to the Elastic dashboard. The notification is serialized as a JSON string
+     * before being published.
+     *
+     * @param notification the {@link Notification} object containing notification details
+     */
+    public static void sendNotification(Notification notification) {
+        try {
+            notificationPublisher.set(objectMapper.writeValueAsString(notification));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Selects the tab of the dashboard with the given name. If no tab matches the name, this will
+     * have no effect on the widgets or tabs in view.
+     *
+     * <p>If the given name is a number, Elastic will select the tab whose index equals the number
+     * provided.
+     *
+     * @param tabName the name of the tab to select
+     */
+    public static void selectTab(String tabName) {
+        selectedTabPublisher.set(tabName);
+    }
+
+    /**
+     * Selects the tab of the dashboard at the given index. If this index is greater than or equal to
+     * the number of tabs, this will have no effect.
+     *
+     * @param tabIndex the index of the tab to select.
+     */
+    public static void selectTab(int tabIndex) {
+        selectTab(Integer.toString(tabIndex));
+    }
+
+    /**
+     * Represents an notification object to be sent to the Elastic dashboard. This object holds
+     * properties such as level, title, description, display time, and dimensions to control how the
+     * notification is displayed on the dashboard.
+     */
+    public static class Notification {
+        @JsonProperty("level")
+        private NotificationLevel level;
+
+        @JsonProperty("title")
+        private String title;
+
+        @JsonProperty("description")
+        private String description;
+
+        @JsonProperty("displayTime")
+        private int displayTimeMillis;
+
+        @JsonProperty("width")
+        private double width;
+
+        @JsonProperty("height")
+        private double height;
+
+        /**
+         * Creates a new Notification with all default parameters. This constructor is intended to be
+         * used with the chainable decorator methods
+         *
+         * <p>Title and description fields are empty.
+         */
+        public Notification() {
+            this(NotificationLevel.INFO, "", "");
+        }
+
+        /**
+         * Creates a new Notification with all properties specified.
+         *
+         * @param level the level of the notification (e.g., INFO, WARNING, ERROR)
+         * @param title the title text of the notification
+         * @param description the descriptive text of the notification
+         * @param displayTimeMillis the time in milliseconds for which the notification is displayed
+         * @param width the width of the notification display area
+         * @param height the height of the notification display area, inferred if below zero
+         */
+        public Notification(
+                NotificationLevel level,
+                String title,
+                String description,
+                int displayTimeMillis,
+                double width,
+                double height) {
+            this.level = level;
+            this.title = title;
+            this.displayTimeMillis = displayTimeMillis;
+            this.description = description;
+            this.height = height;
+            this.width = width;
+        }
+
+        /**
+         * Creates a new Notification with default display time and dimensions.
+         *
+         * @param level the level of the notification
+         * @param title the title text of the notification
+         * @param description the descriptive text of the notification
+         */
+        public Notification(NotificationLevel level, String title, String description) {
+            this(level, title, description, 3000, 350, -1);
+        }
+
+        /**
+         * Creates a new Notification with a specified display time and default dimensions.
+         *
+         * @param level the level of the notification
+         * @param title the title text of the notification
+         * @param description the descriptive text of the notification
+         * @param displayTimeMillis the display time in milliseconds
+         */
+        public Notification(
+                NotificationLevel level, String title, String description, int displayTimeMillis) {
+            this(level, title, description, displayTimeMillis, 350, -1);
+        }
+
+        /**
+         * Creates a new Notification with specified dimensions and default display time. If the height
+         * is below zero, it is automatically inferred based on screen size.
+         *
+         * @param level the level of the notification
+         * @param title the title text of the notification
+         * @param description the descriptive text of the notification
+         * @param width the width of the notification display area
+         * @param height the height of the notification display area, inferred if below zero
+         */
+        public Notification(
+                NotificationLevel level, String title, String description, double width, double height) {
+            this(level, title, description, 3000, width, height);
+        }
+
+        /**
+         * Updates the level of this notification
+         *
+         * @param level the level to set the notification to
+         */
+        public void setLevel(NotificationLevel level) {
+            this.level = level;
+        }
+
+        /**
+         * @return the level of this notification
+         */
+        public NotificationLevel getLevel() {
+            return level;
+        }
+
+        /**
+         * Updates the title of this notification
+         *
+         * @param title the title to set the notification to
+         */
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        /**
+         * Gets the title of this notification
+         *
+         * @return the title of this notification
+         */
+        public String getTitle() {
+            return title;
+        }
+
+        /**
+         * Updates the description of this notification
+         *
+         * @param description the description to set the notification to
+         */
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Updates the display time of the notification
+         *
+         * @param seconds the number of seconds to display the notification for
+         */
+        public void setDisplayTimeSeconds(double seconds) {
+            setDisplayTimeMillis((int) Math.round(seconds * 1000));
+        }
+
+        /**
+         * Updates the display time of the notification in milliseconds
+         *
+         * @param displayTimeMillis the number of milliseconds to display the notification for
+         */
+        public void setDisplayTimeMillis(int displayTimeMillis) {
+            this.displayTimeMillis = displayTimeMillis;
+        }
+
+        /**
+         * Gets the display time of the notification in milliseconds
+         *
+         * @return the number of milliseconds the notification is displayed for
+         */
+        public int getDisplayTimeMillis() {
+            return displayTimeMillis;
+        }
+
+        /**
+         * Updates the width of the notification
+         *
+         * @param width the width to set the notification to
+         */
+        public void setWidth(double width) {
+            this.width = width;
+        }
+
+        /**
+         * Gets the width of the notification
+         *
+         * @return the width of the notification
+         */
+        public double getWidth() {
+            return width;
+        }
+
+        /**
+         * Updates the height of the notification
+         *
+         * <p>If the height is set to -1, the height will be determined automatically by the dashboard
+         *
+         * @param height the height to set the notification to
+         */
+        public void setHeight(double height) {
+            this.height = height;
+        }
+
+        /**
+         * Gets the height of the notification
+         *
+         * @return the height of the notification
+         */
+        public double getHeight() {
+            return height;
+        }
+
+        /**
+         * Modifies the notification's level and returns itself to allow for method chaining
+         *
+         * @param level the level to set the notification to
+         * @return the current notification
+         */
+        public Notification withLevel(NotificationLevel level) {
+            this.level = level;
+            return this;
+        }
+
+        /**
+         * Modifies the notification's title and returns itself to allow for method chaining
+         *
+         * @param title the title to set the notification to
+         * @return the current notification
+         */
+        public Notification withTitle(String title) {
+            setTitle(title);
+            return this;
+        }
+
+        /**
+         * Modifies the notification's description and returns itself to allow for method chaining
+         *
+         * @param description the description to set the notification to
+         * @return the current notification
+         */
+        public Notification withDescription(String description) {
+            setDescription(description);
+            return this;
+        }
+
+        /**
+         * Modifies the notification's display time and returns itself to allow for method chaining
+         *
+         * @param seconds the number of seconds to display the notification for
+         * @return the current notification
+         */
+        public Notification withDisplaySeconds(double seconds) {
+            return withDisplayMilliseconds((int) Math.round(seconds * 1000));
+        }
+
+        /**
+         * Modifies the notification's display time and returns itself to allow for method chaining
+         *
+         * @param displayTimeMillis the number of milliseconds to display the notification for
+         * @return the current notification
+         */
+        public Notification withDisplayMilliseconds(int displayTimeMillis) {
+            setDisplayTimeMillis(displayTimeMillis);
+            return this;
+        }
+
+        /**
+         * Modifies the notification's width and returns itself to allow for method chaining
+         *
+         * @param width the width to set the notification to
+         * @return the current notification
+         */
+        public Notification withWidth(double width) {
+            setWidth(width);
+            return this;
+        }
+
+        /**
+         * Modifies the notification's height and returns itself to allow for method chaining
+         *
+         * @param height the height to set the notification to
+         * @return the current notification
+         */
+        public Notification withHeight(double height) {
+            setHeight(height);
+            return this;
+        }
+
+        /**
+         * Modifies the notification's height and returns itself to allow for method chaining
+         *
+         * <p>This will set the height to -1 to have it automatically determined by the dashboard
+         *
+         * @return the current notification
+         */
+        public Notification withAutomaticHeight() {
+            setHeight(-1);
+            return this;
+        }
+
+        /**
+         * Modifies the notification to disable the auto dismiss behavior
+         *
+         * <p>This sets the display time to 0 milliseconds
+         *
+         * <p>The auto dismiss behavior can be re-enabled by setting the display time to a number
+         * greater than 0
+         *
+         * @return the current notification
+         */
+        public Notification withNoAutoDismiss() {
+            setDisplayTimeMillis(0);
+            return this;
+        }
+
+        /**
+         * Represents the possible levels of notifications for the Elastic dashboard. These levels are
+         * used to indicate the severity or type of notification.
+         */
+        public enum NotificationLevel {
+            /** Informational Message */
+            INFO,
+            /** Warning message */
+            WARNING,
+            /** Error message */
+            ERROR
+        }
+    }
+}

--- a/src/main/java/frc/excalib/control/MathUtils.java
+++ b/src/main/java/frc/excalib/control/MathUtils.java
@@ -10,4 +10,11 @@ public class MathUtils {
     public static double minSize(double val, double sizeLimit) {
         return Math.min(sizeLimit, Math.abs(val)) * Math.signum(val);
     }
+
+    public static double limitTo(double limit, double value) {
+        if ((limit > 0 && limit < value) || (limit < 0 && limit > value)) {
+            return limit;
+        }
+        return value;
+    }
 }

--- a/src/main/java/frc/excalib/control/imu/NavX.java
+++ b/src/main/java/frc/excalib/control/imu/NavX.java
@@ -4,10 +4,13 @@ import com.studica.frc.AHRS;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.util.Units;
+import monologue.Annotations;
+import monologue.Annotations.Log;
+import monologue.Logged;
 
 import static com.studica.frc.AHRS.NavXComType.kMXP_SPI;
 
-public class NavX extends AHRS implements IMU {
+public class NavX extends AHRS implements IMU, Logged {
     private Rotation3d m_offsetRotation;
 
     public NavX(Rotation3d offsetRotation) {
@@ -31,16 +34,19 @@ public class NavX extends AHRS implements IMU {
     }
 
     @Override
+    @Log.NT
     public double getAccX() {
-        return super.getWorldLinearAccelX();
+        return super.getRawAccelX();
     }
 
     @Override
+    @Log.NT
     public double getAccY() {
-        return super.getWorldLinearAccelY();
+        return super.getRawAccelY();
     }
 
     @Override
+    @Log.NT
     public double getAccZ() {
         return super.getWorldLinearAccelZ();
     }

--- a/src/main/java/frc/excalib/control/math/Vector2D.java
+++ b/src/main/java/frc/excalib/control/math/Vector2D.java
@@ -1,6 +1,7 @@
 package frc.excalib.control.math;
 
 import edu.wpi.first.math.geometry.Rotation2d;
+import frc.excalib.control.MathUtils;
 
 /**
  * A class representing a Vector in two dimensions;
@@ -152,5 +153,13 @@ public class Vector2D {
         double magnitude = getDistance();
         this.m_x = magnitude * direction.getCos();
         this.m_y = magnitude * direction.getSin();
+    }
+
+    public Vector2D limit(Vector2D limit) {
+        Vector2D output = new Vector2D(m_x, m_y);
+        output.rotate(limit.getDirection().unaryMinus());
+        output.setX(MathUtils.limitTo(limit.getDistance(), output.m_x));
+        output.setDirection(this.getDirection());
+        return output;
     }
 }

--- a/src/main/java/frc/excalib/mechanisms/linear_extension/LinearExtension.java
+++ b/src/main/java/frc/excalib/mechanisms/linear_extension/LinearExtension.java
@@ -4,9 +4,10 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.TrapezoidProfileCommand;
-import frc.excalib.control.gains.Gains;
+
 import frc.excalib.control.motor.controllers.Motor;
 import frc.excalib.mechanisms.Mechanism;
+import frc.excalib.control.gains.Gains;
 
 import java.util.function.DoubleSupplier;
 

--- a/src/main/java/frc/excalib/slam/mapper/AuroraClient.java
+++ b/src/main/java/frc/excalib/slam/mapper/AuroraClient.java
@@ -1,4 +1,4 @@
-package frc;
+package frc.excalib.slam.mapper;
 
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;

--- a/src/main/java/frc/excalib/slam/mapper/AuroraClient.java
+++ b/src/main/java/frc/excalib/slam/mapper/AuroraClient.java
@@ -5,32 +5,27 @@ import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.networktables.*;
 
 public class AuroraClient {
-    private final NetworkTableInstance instance;
-    private final NetworkTable table;
-    private final NetworkTableEntry xEntry, yEntry, zEntry, rollEntry, pitchEntry, yawEntry;
+    private final NetworkTableInstance m_instance;
+    private final NetworkTable m_table;
+    private final NetworkTableEntry m_xEntry, m_yEntry, m_zEntry, m_rollEntry, m_pitchEntry, m_yawEntry;
 
     public AuroraClient(NetworkTableInstance instance) {
-        this.instance = instance;
-        table = instance.getTable("Aurora/Localization");
-        xEntry = table.getEntry("X");
-        yEntry = table.getEntry("Y");
-        zEntry = table.getEntry("Z");
-        rollEntry = table.getEntry("Roll");
-        pitchEntry = table.getEntry("Pitch");
-        yawEntry = table.getEntry("Yaw");
+        m_instance = instance;
+        m_table = m_instance.getTable("Aurora/Localization");
+        m_xEntry = m_table.getEntry("X");
+        m_yEntry = m_table.getEntry("Y");
+        m_zEntry = m_table.getEntry("Z");
+        m_rollEntry = m_table.getEntry("Roll");
+        m_pitchEntry = m_table.getEntry("Pitch");
+        m_yawEntry = m_table.getEntry("Yaw");
     }
 
 
     public Pose3d getPose() {
         Pose3d pose = new Pose3d(
-                xEntry.getDouble(-1),
-                yEntry.getDouble(-1),
-                zEntry.getDouble(-1),
-                new Rotation3d(
-                        rollEntry.getDouble(100),
-                        pitchEntry.getDouble(100),
-                        yawEntry.getDouble(100)));
-
+                getX(), getY(), getZ(),
+                new Rotation3d(getRoll(), getPitch(), getYaw())
+        );
         if (pose.getX() == -1 ||
                 pose.getY() == -1 ||
                 pose.getZ() == -1 ||
@@ -40,27 +35,27 @@ public class AuroraClient {
         return pose;
     }
 
-    public double getX () {
-        if (xEntry==null) System.out.println("yehuda");
-        return xEntry.getDouble(-1);
+    public double getX() {
+        return m_xEntry.getDouble(-1);
     }
 
-    public double getY () {
-        return yEntry.getDouble(-1);
+    public double getY() {
+        return m_yEntry.getDouble(-1);
     }
 
-    public double getZ () {
-        return zEntry.getDouble(-1);
-    }
-    public double getRoll () {
-        return rollEntry.getDouble(100);
+    public double getZ() {
+        return m_zEntry.getDouble(-1);
     }
 
-    public double getPitch () {
-        return pitchEntry.getDouble(100);
+    public double getRoll() {
+        return m_rollEntry.getDouble(100);
     }
 
-    public double getYaw () {
-        return yawEntry.getDouble(100);
+    public double getPitch() {
+        return m_pitchEntry.getDouble(100);
+    }
+
+    public double getYaw() {
+        return m_yawEntry.getDouble(100);
     }
 }

--- a/src/main/java/frc/excalib/swerve/ModulesHolder.java
+++ b/src/main/java/frc/excalib/swerve/ModulesHolder.java
@@ -121,29 +121,27 @@ public class ModulesHolder implements Logged {
      */
     public Command setVelocitiesCommand(Supplier<Vector2D> translationalVel, DoubleSupplier omega) {
         return new ParallelCommandGroup(
-                m_frontLeft.setVelocityCommand(() -> computeModuleVelocity(m_frontLeft, translationalVel, omega)),
-                m_frontRight.setVelocityCommand(() -> computeModuleVelocity(m_frontRight, translationalVel, omega)),
-                m_backLeft.setVelocityCommand(() -> computeModuleVelocity(m_backLeft, translationalVel, omega)),
-                m_backRight.setVelocityCommand(() -> computeModuleVelocity(m_backRight, translationalVel, omega))
+                m_frontLeft.setVelocityCommand(
+                        translationalVel,
+                        omega,
+                        () -> calcVelocityRatioLimit(translationalVel.get(), omega.getAsDouble())
+                ),
+                m_frontRight.setVelocityCommand(
+                        translationalVel,
+                        omega,
+                        () -> calcVelocityRatioLimit(translationalVel.get(), omega.getAsDouble())
+                ),
+                m_backLeft.setVelocityCommand(
+                        translationalVel,
+                        omega,
+                        () -> calcVelocityRatioLimit(translationalVel.get(), omega.getAsDouble())
+                ),
+                m_backRight.setVelocityCommand(
+                        translationalVel,
+                        omega,
+                        () -> calcVelocityRatioLimit(translationalVel.get(), omega.getAsDouble())
+                )
         );
-    }
-
-    /**
-     * Computes the desired velocity for a module.
-     *
-     * @param module The swerve module.
-     * @param tVel   The desired translation velocity supplier.
-     * @param omega  The desired rotation rate supplier.
-     * @return The computed module velocity.
-     */
-    private Vector2D computeModuleVelocity(SwerveModule module, Supplier<Vector2D> tVel, DoubleSupplier omega) {
-        Vector2D translationVelocity = tVel.get();
-        double omegaRadPerSec = omega.getAsDouble();
-
-        // Since calcVelocityRatio is the same for all modules, compute it once
-        double velocityRatioLimit = calcVelocityRatioLimit(translationVelocity, omegaRadPerSec);
-
-        return module.getSigmaVelocity(translationVelocity, omegaRadPerSec, velocityRatioLimit);
     }
 
     public void setModulesStates(SwerveModuleState[] states) {

--- a/src/main/java/frc/excalib/swerve/Swerve.java
+++ b/src/main/java/frc/excalib/swerve/Swerve.java
@@ -149,22 +149,23 @@ public class Swerve extends SubsystemBase implements Logged {
         return AutoBuilder.pathfindToPose(
                 setPoint,
                 MAX_PATH_CONSTRAINTS
-        );
+        ).withName("Pathfinding Command");
     }
 
     public Command driveToPoseWithOverrideCommand(
             Pose2d setPoint,
+            BooleanSupplier override,
             Supplier<Vector2D> velocityMPS,
             DoubleSupplier omegaRadPerSec) {
         Command driveToPoseCommand = driveToPoseCommand(setPoint);
         return new SequentialCommandGroup(
-                driveToPoseCommand.until(() -> velocityMPS.get().getDistance() != 0),
+                driveToPoseCommand.until(() -> velocityMPS.get().getDistance() != 0 && override.getAsBoolean()),
                 driveCommand(
                         velocityMPS,
                         omegaRadPerSec,
                         () -> true
                 ).until(() -> velocityMPS.get().getDistance() == 0)
-        ).repeatedly().until(driveToPoseCommand::isFinished);
+        ).repeatedly().until(driveToPoseCommand::isFinished).withName("Pathfinding With Override Command");
     }
 
     /**
@@ -243,8 +244,8 @@ public class Swerve extends SubsystemBase implements Logged {
      * @return The robot's acceleration as a Vector2D.
      */
     @Log.NT(key = "Acceleration")
-    public Vector2D getAcceleration() {
-        return new Vector2D(m_imu.getAccX(), m_imu.getAccY());
+    public double getAccelerationDistance() {
+        return new Vector2D(m_imu.getAccX(), m_imu.getAccY()).getDistance();
     }
 
     /**

--- a/src/main/java/frc/excalib/swerve/Swerve.java
+++ b/src/main/java/frc/excalib/swerve/Swerve.java
@@ -19,6 +19,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.excalib.control.imu.IMU;
@@ -152,7 +153,7 @@ public class Swerve extends SubsystemBase implements Logged {
         try {
             path = PathPlannerPath.fromPathFile(pathName);
         } catch (IOException | ParseException e) {
-            throw new RuntimeException(e);
+            return new PrintCommand("this path file doesn't exist");
         }
 
         return AutoBuilder.pathfindThenFollowPath(

--- a/src/main/java/frc/excalib/swerve/Swerve.java
+++ b/src/main/java/frc/excalib/swerve/Swerve.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 import static edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets.kTextView;
 import static edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior.kCancelSelf;
 import static frc.excalib.additional_utilities.Elastic.Notification.NotificationLevel.WARNING;
+import static frc.excalib.swerve.SwerveAccUtils.getSmartTranslationalVelocitySetPoint;
 import static frc.robot.Constants.SwerveConstants.*;
 import static monologue.Annotations.*;
 
@@ -99,8 +100,8 @@ public class Swerve extends SubsystemBase implements Logged {
 
         // Precompute values to avoid redundant calculations
         Supplier<Vector2D> adjustedVelocitySupplier = () -> {
-            Vector2D velocity = velocityMPS.get();
-//            Vector2D velocity = getSmartTranslationalVelocitySetPoint(getVelocity(), velocityMPS.get());
+//            Vector2D velocity = velocityMPS.get();
+            Vector2D velocity = getSmartTranslationalVelocitySetPoint(getVelocity(), velocityMPS.get());
             if (fieldOriented.getAsBoolean()) {
                 Rotation2d yaw = getRotation2D().unaryMinus();
                 return velocity.rotate(yaw);

--- a/src/main/java/frc/excalib/swerve/Swerve.java
+++ b/src/main/java/frc/excalib/swerve/Swerve.java
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
+import frc.excalib.additional_utilities.Elastic;
 import frc.excalib.control.imu.IMU;
 import frc.excalib.control.math.Vector2D;
 import frc.excalib.slam.mapper.Odometry;
@@ -35,6 +36,7 @@ import java.util.function.Supplier;
 
 import static edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets.kTextView;
 import static edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior.kCancelSelf;
+import static frc.excalib.additional_utilities.Elastic.Notification.NotificationLevel.WARNING;
 import static frc.robot.Constants.SwerveConstants.*;
 import static monologue.Annotations.*;
 
@@ -153,6 +155,11 @@ public class Swerve extends SubsystemBase implements Logged {
         try {
             path = PathPlannerPath.fromPathFile(pathName);
         } catch (IOException | ParseException e) {
+            Elastic.sendNotification(new Elastic.Notification(
+                    WARNING,
+                    "Path Creating Error",
+                    "the path file " + pathName + " doesn't exist")
+            );
             return new PrintCommand("this path file doesn't exist");
         }
 

--- a/src/main/java/frc/excalib/swerve/Swerve.java
+++ b/src/main/java/frc/excalib/swerve/Swerve.java
@@ -14,7 +14,8 @@ import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
-import edu.wpi.first.wpilibj.shuffleboard.*;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -23,6 +24,7 @@ import edu.wpi.first.wpilibj2.command.PrintCommand;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Direction;
 import frc.excalib.additional_utilities.Elastic;
+import frc.excalib.commands.ContinuouslyConditionalCommand;
 import frc.excalib.control.imu.IMU;
 import frc.excalib.control.math.Vector2D;
 import frc.excalib.slam.mapper.Odometry;
@@ -36,9 +38,8 @@ import java.util.function.Supplier;
 
 import static edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets.kTextView;
 import static frc.excalib.additional_utilities.Elastic.Notification.NotificationLevel.WARNING;
-import static frc.excalib.swerve.SwerveAccUtils.getSmartTranslationalVelocitySetPoint;
 import static frc.robot.Constants.SwerveConstants.*;
-import static monologue.Annotations.*;
+import static monologue.Annotations.Log;
 
 /**
  * A class representing a swerve subsystem.
@@ -150,8 +151,12 @@ public class Swerve extends SubsystemBase implements Logged {
     public Command driveToPoseCommand(Pose2d setPoint) {
         return AutoBuilder.pathfindToPose(
                 setPoint,
-                new PathConstraints(MAX_VEL, MAX_FORWARD_ACC, MAX_OMEGA_RAD_PER_SEC, MAX_OMEGA_RAD_PER_SEC, 12.0, false)
-        );
+                new PathConstraints(MAX_VEL, MAX_FORWARD_ACC,
+                        MAX_OMEGA_RAD_PER_SEC,
+                        MAX_OMEGA_RAD_PER_SEC,
+                        12.0,
+                        false
+                ));
     }
 
     public Command pathfindThenFollowPathCommand(String pathName) {

--- a/src/main/java/frc/excalib/swerve/Swerve.java
+++ b/src/main/java/frc/excalib/swerve/Swerve.java
@@ -5,6 +5,7 @@ import com.pathplanner.lib.config.PIDConstants;
 import com.pathplanner.lib.config.RobotConfig;
 import com.pathplanner.lib.controllers.PPHolonomicDriveController;
 import com.pathplanner.lib.path.PathConstraints;
+import com.pathplanner.lib.path.PathPlannerPath;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -24,7 +25,9 @@ import frc.excalib.control.imu.IMU;
 import frc.excalib.control.math.Vector2D;
 import frc.excalib.slam.mapper.Odometry;
 import monologue.Logged;
+import org.json.simple.parser.ParseException;
 
+import java.io.IOException;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
@@ -140,6 +143,20 @@ public class Swerve extends SubsystemBase implements Logged {
     public Command driveToPoseCommand(Pose2d setPoint) {
         return AutoBuilder.pathfindToPose(
                 setPoint,
+                new PathConstraints(MAX_VEL, MAX_FORWARD_ACC, MAX_OMEGA_RAD_PER_SEC, MAX_OMEGA_RAD_PER_SEC, 12.0, false)
+        );
+    }
+
+    public Command pathfindThenFollowPathCommand(String pathName) {
+        PathPlannerPath path;
+        try {
+            path = PathPlannerPath.fromPathFile(pathName);
+        } catch (IOException | ParseException e) {
+            throw new RuntimeException(e);
+        }
+
+        return AutoBuilder.pathfindThenFollowPath(
+                path,
                 new PathConstraints(MAX_VEL, MAX_FORWARD_ACC, MAX_OMEGA_RAD_PER_SEC, MAX_OMEGA_RAD_PER_SEC, 12.0, false)
         );
     }

--- a/src/main/java/frc/excalib/swerve/SwerveAccUtils.java
+++ b/src/main/java/frc/excalib/swerve/SwerveAccUtils.java
@@ -30,8 +30,8 @@ public class SwerveAccUtils {
     private static Vector2D applyAccelerationLimits(Vector2D currentVel, Vector2D velocityError) {
         Vector2D wantedAcceleration = velocityError.mul(1 / CYCLE_TIME);
 
-        wantedAcceleration = applyForwardLimit(currentVel, wantedAcceleration);
-        wantedAcceleration = applyTiltLimit(wantedAcceleration);
+//        wantedAcceleration = applyForwardLimit(currentVel, wantedAcceleration);
+//        wantedAcceleration = applyTiltLimit(wantedAcceleration);
         wantedAcceleration = applySkidLimit(wantedAcceleration);
 
         return wantedAcceleration.mul(CYCLE_TIME);
@@ -48,14 +48,7 @@ public class SwerveAccUtils {
                 MAX_FORWARD_ACC *
                         (1 - (currentVel.getDistance() / MAX_VEL));
 
-        Vector2D rotatedWantedAcceleration = wantedAcceleration.rotate(
-                wantedAcceleration.getDirection().minus(currentVel.getDirection()));
-        rotatedWantedAcceleration = new Vector2D(
-                minSize(rotatedWantedAcceleration.getX(), maxAcceleration),
-                rotatedWantedAcceleration.getDirection());
-        wantedAcceleration = rotatedWantedAcceleration.rotate(
-                currentVel.getDirection().minus(wantedAcceleration.getDirection()));
-
+        wantedAcceleration = wantedAcceleration.limit(new Vector2D(maxAcceleration, currentVel.getDirection()));
         return wantedAcceleration;
     }
 
@@ -79,7 +72,7 @@ public class SwerveAccUtils {
      */
     private static Vector2D applySkidLimit(Vector2D wantedAcceleration) {
         return new Vector2D(
-                minSize(wantedAcceleration.getDistance(), MAX_SKID_ACC),
+                Math.min(wantedAcceleration.getDistance(), MAX_SKID_ACC),
                 wantedAcceleration.getDirection()
         );
     }

--- a/src/main/java/frc/excalib/swerve/SwerveAccUtils.java
+++ b/src/main/java/frc/excalib/swerve/SwerveAccUtils.java
@@ -15,8 +15,8 @@ public class SwerveAccUtils {
      * @return translational velocity setpoint
      */
     public static Vector2D getSmartTranslationalVelocitySetPoint(Vector2D currentVel, Vector2D velocitySetPoint) {
-        Vector2D deltaVelocity = currentVel.plus(
-                velocitySetPoint.mul(-1));
+        Vector2D deltaVelocity = velocitySetPoint.plus(
+                currentVel.mul(-1));
         Vector2D actualDeltaVelocity = applyAccelerationLimits(currentVel, deltaVelocity);
         return currentVel.plus(actualDeltaVelocity);
     }

--- a/src/main/java/frc/excalib/swerve/SwerveModule.java
+++ b/src/main/java/frc/excalib/swerve/SwerveModule.java
@@ -34,6 +34,7 @@ public class SwerveModule implements Logged {
     private final double m_MAX_VEL;
     private final Rotation2d m_moduleAnglePlus90;
     private final Vector2D m_setPoint = new Vector2D(0, 0);
+    private double m_lastDirection;
 
     /**
      * A constructor for the SwerveModule
@@ -99,11 +100,10 @@ public class SwerveModule implements Logged {
     }
 
     public Command setVelocityCommand(Supplier<Vector2D> moduleVelocity) {
+        Vector2D velocity = moduleVelocity.get();
+        double speed = velocity.getDistance();
         return new ParallelCommandGroup(
                 m_driveWheel.setDynamicVelocityCommand(() -> {
-                    Vector2D velocity = moduleVelocity.get();
-                    double speed = velocity.getDistance();
-
                     if (speed < 0.1) {
                         return 0.0;
                     }
@@ -112,9 +112,6 @@ public class SwerveModule implements Logged {
                     return optimize ? -speed : speed;
                 }),
                 m_turret.setPositionCommand(() -> {
-                    Vector2D velocity = moduleVelocity.get();
-                    double speed = velocity.getDistance();
-
                     if (speed < 0.1) {
                         return m_turret.getPosition();
                     }

--- a/src/main/java/frc/excalib/swerve/SwerveModule.java
+++ b/src/main/java/frc/excalib/swerve/SwerveModule.java
@@ -34,7 +34,6 @@ public class SwerveModule implements Logged {
     private final double m_MAX_VEL;
     private final Rotation2d m_moduleAnglePlus90;
     private final Vector2D m_setPoint = new Vector2D(0, 0);
-    private double m_lastDirection;
 
     /**
      * A constructor for the SwerveModule
@@ -100,10 +99,11 @@ public class SwerveModule implements Logged {
     }
 
     public Command setVelocityCommand(Supplier<Vector2D> moduleVelocity) {
-        Vector2D velocity = moduleVelocity.get();
-        double speed = velocity.getDistance();
         return new ParallelCommandGroup(
                 m_driveWheel.setDynamicVelocityCommand(() -> {
+                    Vector2D velocity = moduleVelocity.get();
+                    double speed = velocity.getDistance();
+
                     if (speed < 0.1) {
                         return 0.0;
                     }
@@ -112,6 +112,9 @@ public class SwerveModule implements Logged {
                     return optimize ? -speed : speed;
                 }),
                 m_turret.setPositionCommand(() -> {
+                    Vector2D velocity = moduleVelocity.get();
+                    double speed = velocity.getDistance();
+
                     if (speed < 0.1) {
                         return m_turret.getPosition();
                     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -61,7 +61,7 @@ public final class Constants {
         public static final double MAX_MODULE_VEL = 4.45;
         public static final double MAX_FRONT_ACC = 2;
         public static final double MAX_SIDE_ACC = 6;
-        public static final double MAX_SKID_ACC = 6;
+        public static final double MAX_SKID_ACC = 60;
         public static final double MAX_FORWARD_ACC = 9;
         public static final double MAX_VEL = 4.45;
         public static final double MAX_OMEGA_RAD_PER_SEC = 6; //11.5

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -46,18 +46,22 @@ public final class Constants {
         private static final double PID_TOLERANCE = 0.2;
 
         public static final double TRACK_WIDTH = 0.51; // m
-        public static final Translation2d FRONT_LEFT_TRANSLATION = new Translation2d(
-                TRACK_WIDTH / 2, TRACK_WIDTH / 2
-        );
-        public static final Translation2d FRONT_RIGHT_TRANSLATION = new Translation2d(
-                TRACK_WIDTH / 2, -TRACK_WIDTH / 2
-        );
-        public static final Translation2d BACK_LEFT_TRANSLATION = new Translation2d(
-                -TRACK_WIDTH / 2, TRACK_WIDTH / 2
-        );
-        public static final Translation2d BACK_RIGHT_TRANSLATION = new Translation2d(
-                -TRACK_WIDTH / 2, -TRACK_WIDTH / 2
-        );
+        public static final Translation2d FRONT_LEFT_TRANSLATION =
+                new Translation2d(
+                        TRACK_WIDTH / 2, TRACK_WIDTH / 2
+                );
+        public static final Translation2d FRONT_RIGHT_TRANSLATION =
+                new Translation2d(
+                        TRACK_WIDTH / 2, -TRACK_WIDTH / 2
+                );
+        public static final Translation2d BACK_LEFT_TRANSLATION =
+                new Translation2d(
+                        -TRACK_WIDTH / 2, TRACK_WIDTH / 2
+                );
+        public static final Translation2d BACK_RIGHT_TRANSLATION =
+                new Translation2d(
+                        -TRACK_WIDTH / 2, -TRACK_WIDTH / 2
+                );
 
         public static final double MAX_MODULE_VEL = 4.45;
         public static final double MAX_FRONT_ACC = 2;
@@ -65,7 +69,7 @@ public final class Constants {
         public static final double MAX_SKID_ACC = 60;
         public static final double MAX_FORWARD_ACC = 9;
         public static final double MAX_VEL = 4.45;
-        public static final double MAX_OMEGA_RAD_PER_SEC = 6; //11.5
+        public static final double MAX_OMEGA_RAD_PER_SEC = 6;
 
         public static final PathConstraints MAX_PATH_CONSTRAINTS = new PathConstraints(
                 MAX_VEL,
@@ -83,9 +87,11 @@ public final class Constants {
         private static final double VELOCITY_CONVERSION_FACTOR = Units.inchesToMeters(4) * Math.PI / 6.12;
         private static final double POSITION_CONVERSION_FACTOR = Units.inchesToMeters(4) * Math.PI / 6.12;
         private static final double ROTATION_VELOCITY_CONVERSION_FACTOR = (2 * Math.PI) / (21.4285714);
-        public static final PIDConstants ANGLE_PID_CONSTANTS =  new PIDConstants(1.4, 0.0, 0.0);
+        public static final PIDConstants ANGLE_PID_CONSTANTS = new PIDConstants(1.4, 0.0, 0.0);
 
         public static final NavX GYRO = new NavX(new Rotation3d());
+
+        public static final double DEADBAND_VALUE = 0.15;
 
         public static Command resetAngleCommand() {
             return new InstantCommand(GYRO::resetIMU).ignoringDisable(true);

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -6,6 +6,7 @@ package frc.robot;
 
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.pathplanner.lib.config.PIDConstants;
+import com.pathplanner.lib.path.PathConstraints;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -66,6 +67,15 @@ public final class Constants {
         public static final double MAX_VEL = 4.45;
         public static final double MAX_OMEGA_RAD_PER_SEC = 6; //11.5
 
+        public static final PathConstraints MAX_PATH_CONSTRAINTS = new PathConstraints(
+                MAX_VEL,
+                MAX_FORWARD_ACC,
+                MAX_OMEGA_RAD_PER_SEC,
+                MAX_OMEGA_RAD_PER_SEC, //TODO: find angular acc max value
+                12.0,
+                false
+        );
+
         private static final CANcoder FRONT_LEFT_ABS_ENCODER = new CANcoder(13);
         public static final CANcoder FRONT_RIGHT_ABS_ENCODER = new CANcoder(10);
         private static final CANcoder BACK_LEFT_ABS_ENCODER = new CANcoder(12);
@@ -77,7 +87,7 @@ public final class Constants {
 
         public static final NavX GYRO = new NavX(new Rotation3d());
 
-        public static Command resetSwerveCommand() {
+        public static Command resetAngleCommand() {
             return new InstantCommand(GYRO::resetIMU).ignoringDisable(true);
         }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -14,16 +14,11 @@ import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.excalib.slam.mapper.AuroraClient;
 import monologue.Monologue;
 
-/**
- * The methods in this class are called automatically corresponding to each mode, as described in
- * the TimedRobot documentation. If you change the name of this class or the package after creating
- * this project, you must also update the Main.java file in the project.
- */
 public class Robot extends TimedRobot {
     private Command m_autonomousCommand;
 
     private final RobotContainer m_robotContainer;
-    private AuroraClient auroraClient;
+    private AuroraClient m_auroraClient ;
 
     /**
      * This function is run when the robot is first started up and should be used for any
@@ -31,8 +26,8 @@ public class Robot extends TimedRobot {
      */
     public Robot() {
 
-        // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
-        // autonomous chooser on the dashboard.
+        // Instantiate our RobotContainer.
+        // This will perform all our button bindings, and put our autonomous chooser on the dashboard.
         m_robotContainer = new RobotContainer();
     }
 
@@ -43,8 +38,7 @@ public class Robot extends TimedRobot {
         Monologue.setupMonologue(m_robotContainer, "Robot", fileOnly, lazyLogging);
 
         WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
-        auroraClient = new AuroraClient(NetworkTableInstance.getDefault());
-//    addPeriodic(m_robotContainer.updateOdometry, 0.01);
+        m_auroraClient = new AuroraClient(NetworkTableInstance.getDefault());
     }
 
     /**
@@ -57,12 +51,7 @@ public class Robot extends TimedRobot {
     @Override
     public void robotPeriodic() {
         Monologue.setFileOnly(DriverStation.isFMSAttached());
-        // This method needs to be called periodically, or no logging annotations will process properly.
         Monologue.updateAll();
-        // Runs the Scheduler.  This is responsible for polling buttons, adding newly-scheduled
-        // commands, running already-scheduled commands, removing finished or interrupted commands,
-        // and running subsystem periodic() methods.  This must be called from the robot's periodic
-        // block in order for anything in the Command-based framework to work.
         CommandScheduler.getInstance().run();
     }
 
@@ -99,10 +88,6 @@ public class Robot extends TimedRobot {
 
     @Override
     public void teleopInit() {
-        // This makes sure that the autonomous stops running when
-        // teleop starts running. If you want the autonomous to
-        // continue until interrupted by another command, remove
-        // this line or comment it out.
         if (m_autonomousCommand != null) {
             m_autonomousCommand.cancel();
         }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,12 +5,14 @@
 package frc.robot;
 
 import edu.wpi.first.net.WebServer;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.AuroraClient;
 import monologue.Monologue;
 
 /**
@@ -19,102 +21,126 @@ import monologue.Monologue;
  * this project, you must also update the Main.java file in the project.
  */
 public class Robot extends TimedRobot {
-  private Command m_autonomousCommand;
+    private Command m_autonomousCommand;
 
-  private final RobotContainer m_robotContainer;
+    private final RobotContainer m_robotContainer;
+    private AuroraClient auroraClient;
 
-  /**
-   * This function is run when the robot is first started up and should be used for any
-   * initialization code.
-   */
-  public Robot() {
+    /**
+     * This function is run when the robot is first started up and should be used for any
+     * initialization code.
+     */
+    public Robot() {
 
-    // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
-    // autonomous chooser on the dashboard.
-    m_robotContainer = new RobotContainer();
-  }
+        // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
+        // autonomous chooser on the dashboard.
+        m_robotContainer = new RobotContainer();
+    }
 
-  @Override
-  public void robotInit(){
-    boolean fileOnly = false;
-    boolean lazyLogging = false;
-    Monologue.setupMonologue(m_robotContainer, "Robot", fileOnly, lazyLogging);
+    @Override
+    public void robotInit() {
+        boolean fileOnly = false;
+        boolean lazyLogging = false;
+        Monologue.setupMonologue(m_robotContainer, "Robot", fileOnly, lazyLogging);
 
-    WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
-  }
-  /**
-   * This function is called every 20 ms, no matter the mode. Use this for items like diagnostics
-   * that you want ran during disabled, autonomous, teleoperated and test.
-   *
-   * <p>This runs after the mode specific periodic functions, but before LiveWindow and
-   * SmartDashboard integrated updating.
-   */
-  @Override
-  public void robotPeriodic() {
-    Monologue.setFileOnly(DriverStation.isFMSAttached());
-    // This method needs to be called periodically, or no logging annotations will process properly.
-    Monologue.updateAll();
-    // Runs the Scheduler.  This is responsible for polling buttons, adding newly-scheduled
-    // commands, running already-scheduled commands, removing finished or interrupted commands,
-    // and running subsystem periodic() methods.  This must be called from the robot's periodic
-    // block in order for anything in the Command-based framework to work.
-    CommandScheduler.getInstance().run();
+        WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
+        auroraClient = new AuroraClient(NetworkTableInstance.getDefault());
+    }
+
+    /**
+     * This function is called every 20 ms, no matter the mode. Use this for items like diagnostics
+     * that you want ran during disabled, autonomous, teleoperated and test.
+     *
+     * <p>This runs after the mode specific periodic functions, but before LiveWindow and
+     * SmartDashboard integrated updating.
+     */
+    @Override
+    public void robotPeriodic() {
+        Monologue.setFileOnly(DriverStation.isFMSAttached());
+        // This method needs to be called periodically, or no logging annotations will process properly.
+        Monologue.updateAll();
+        // Runs the Scheduler.  This is responsible for polling buttons, adding newly-scheduled
+        // commands, running already-scheduled commands, removing finished or interrupted commands,
+        // and running subsystem periodic() methods.  This must be called from the robot's periodic
+        // block in order for anything in the Command-based framework to work.
+        CommandScheduler.getInstance().run();
 
 //    addPeriodic(m_robotContainer.updateOdometry, 0.01);
-  }
-
-  /** This function is called once each time the robot enters Disabled mode. */
-  @Override
-  public void disabledInit() {}
-
-  @Override
-  public void disabledPeriodic() {}
-
-  /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
-  @Override
-  public void autonomousInit() {
-    m_autonomousCommand = m_robotContainer.getAutonomousCommand();
-
-    // schedule the autonomous command (example)
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.schedule();
     }
-  }
 
-  /** This function is called periodically during autonomous. */
-  @Override
-  public void autonomousPeriodic() {}
-
-  @Override
-  public void teleopInit() {
-    // This makes sure that the autonomous stops running when
-    // teleop starts running. If you want the autonomous to
-    // continue until interrupted by another command, remove
-    // this line or comment it out.
-    if (m_autonomousCommand != null) {
-      m_autonomousCommand.cancel();
+    /**
+     * This function is called once each time the robot enters Disabled mode.
+     */
+    @Override
+    public void disabledInit() {
     }
-  }
 
-  /** This function is called periodically during operator control. */
-  @Override
-  public void teleopPeriodic() {}
+    @Override
+    public void disabledPeriodic() {
+    }
 
-  @Override
-  public void testInit() {
-    // Cancels all running commands at the start of test mode.
-    CommandScheduler.getInstance().cancelAll();
-  }
+    /**
+     * This autonomous runs the autonomous command selected by your {@link RobotContainer} class.
+     */
+    @Override
+    public void autonomousInit() {
+        m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
-  /** This function is called periodically during test mode. */
-  @Override
-  public void testPeriodic() {}
+        // schedule the autonomous command (example)
+        if (m_autonomousCommand != null) {
+            m_autonomousCommand.schedule();
+        }
+    }
 
-  /** This function is called once when the robot is first started up. */
-  @Override
-  public void simulationInit() {}
+    /**
+     * This function is called periodically during autonomous.
+     */
+    @Override
+    public void autonomousPeriodic() {
+    }
 
-  /** This function is called periodically whilst in simulation. */
-  @Override
-  public void simulationPeriodic() {}
+    @Override
+    public void teleopInit() {
+        // This makes sure that the autonomous stops running when
+        // teleop starts running. If you want the autonomous to
+        // continue until interrupted by another command, remove
+        // this line or comment it out.
+        if (m_autonomousCommand != null) {
+            m_autonomousCommand.cancel();
+        }
+    }
+
+    /**
+     * This function is called periodically during operator control.
+     */
+    @Override
+    public void teleopPeriodic() {
+    }
+
+    @Override
+    public void testInit() {
+        // Cancels all running commands at the start of test mode.
+        CommandScheduler.getInstance().cancelAll();
+    }
+
+    /**
+     * This function is called periodically during test mode.
+     */
+    @Override
+    public void testPeriodic() {
+    }
+
+    /**
+     * This function is called once when the robot is first started up.
+     */
+    @Override
+    public void simulationInit() {
+    }
+
+    /**
+     * This function is called periodically whilst in simulation.
+     */
+    @Override
+    public void simulationPeriodic() {
+    }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -44,6 +44,7 @@ public class Robot extends TimedRobot {
 
         WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
         auroraClient = new AuroraClient(NetworkTableInstance.getDefault());
+//    addPeriodic(m_robotContainer.updateOdometry, 0.01);
     }
 
     /**
@@ -63,8 +64,6 @@ public class Robot extends TimedRobot {
         // and running subsystem periodic() methods.  This must be called from the robot's periodic
         // block in order for anything in the Command-based framework to work.
         CommandScheduler.getInstance().run();
-
-//    addPeriodic(m_robotContainer.updateOdometry, 0.01);
     }
 
     /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -9,10 +9,9 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.AuroraClient;
+import frc.excalib.slam.mapper.AuroraClient;
 import monologue.Monologue;
 
 /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,27 +20,19 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.*;
 import edu.wpi.first.wpilibj2.command.button.CommandPS5Controller;
-import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.excalib.control.math.Vector2D;
 import frc.excalib.swerve.Swerve;
 import monologue.Logged;
 
 import static frc.robot.Constants.SwerveConstants.*;
 
-/**
- * This class is where the bulk of the robot should be declared. Since Command-based is a
- * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
- * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
- * subsystems, commands, and trigger mappings) should be declared here.
- */
 public class RobotContainer implements Logged {
-    private final BuiltInAccelerometer accelerometer = new BuiltInAccelerometer();
+    private final BuiltInAccelerometer m_accelerometer = new BuiltInAccelerometer();
     // The robot's subsystems and commands are defined here...
 
     private final Swerve m_swerve = configureSwerve(new Pose2d());
 
-    private final CommandPS5Controller driver = new CommandPS5Controller(0);
+    private final CommandPS5Controller m_driver = new CommandPS5Controller(0);
 
     private final InterpolatingDoubleTreeMap m_decelerator = new InterpolatingDoubleTreeMap();
 
@@ -48,9 +40,6 @@ public class RobotContainer implements Logged {
 
     private SendableChooser<Command> m_autoChooser;
 
-    /**
-     * The container for the robot. Contains subsystems, OI devices, and commands.
-     */
     public RobotContainer() {
         m_decelerator.put(-1.0, 1.0);
         m_decelerator.put(1.0, 0.25);
@@ -62,42 +51,34 @@ public class RobotContainer implements Logged {
         configureBindings();
     }
 
-    /**
-     * Use this method to define your trigger->command mappings. Triggers can be created via the
-     * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with an arbitrary
-     * predicate, or via the named factories in {@link
-     * edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses for {@link
-     * CommandXboxController Xbox}/{@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller
-     * PS4} controllers or {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick Flight
-     * joysticks}.
-     */
+
     private void configureBindings() {
         m_swerve.setDefaultCommand(
                 m_swerve.driveCommand(
                         () -> new Vector2D(
-                                deadband(-driver.getLeftY()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3)),
-                                deadband(-driver.getLeftX()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3))),
-                        () -> deadband(-driver.getRightX()) * MAX_OMEGA_RAD_PER_SEC,
+                                deadband(-m_driver.getLeftY()) * MAX_VEL * m_decelerator.get(m_driver.getRawAxis(3)),
+                                deadband(-m_driver.getLeftX()) * MAX_VEL * m_decelerator.get(m_driver.getRawAxis(3))),
+                        () -> deadband(-m_driver.getRightX()) * MAX_OMEGA_RAD_PER_SEC,
                         () -> true
                 ));
 
-        driver.PS().onTrue(resetAngleCommand());
+        m_driver.PS().onTrue(resetAngleCommand());
 
-        driver.cross().onTrue(
+        m_driver.cross().onTrue(
                 m_swerve.driveToPoseWithOverrideCommand(
                         new Pose2d(1, 0, new Rotation2d()),
-                        driver.R2(),
+                        m_driver.R2(),
                         () -> new Vector2D(
-                                deadband(-driver.getLeftY()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3)),
-                                deadband(-driver.getLeftX()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3))),
-                        () -> deadband(-driver.getRightX()) * MAX_OMEGA_RAD_PER_SEC
+                                deadband(-m_driver.getLeftY()) * MAX_VEL * m_decelerator.get(m_driver.getRawAxis(3)),
+                                deadband(-m_driver.getLeftX()) * MAX_VEL * m_decelerator.get(m_driver.getRawAxis(3))),
+                        () -> deadband(-m_driver.getRightX()) * MAX_OMEGA_RAD_PER_SEC
                 )
         );
     }
 
 
     public double deadband(double value) {
-        return Math.abs(value) < 0.15 ? 0 : value;
+        return Math.abs(value) < DEADBAND_VALUE ? 0 : value;
     }
 
     private void initAutoChooser() {
@@ -126,27 +107,27 @@ public class RobotContainer implements Logged {
 
         ShuffleboardTab swerveTab = Shuffleboard.getTab("Swerve");
         SendableChooser<Rotation2d> angleChooser = new SendableChooser<>();
+
+        // angle chooser options
         angleChooser.setDefaultOption("0", new Rotation2d());
         angleChooser.addOption("90", new Rotation2d(Math.PI / 2));
         angleChooser.addOption("180", new Rotation2d(Math.PI));
         angleChooser.addOption("270", new Rotation2d(3 * Math.PI / 2));
+
         swerveTab.add("Angle Chooser", angleChooser);
+
         swerveTab.add("Turn To Angle",
                 m_swerve.turnToAngleCommand(
                         () -> new Vector2D(
-                                deadband(-driver.getLeftY()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3)),
-                                deadband(-driver.getLeftX()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3)
+                                deadband(-m_driver.getLeftY()) * MAX_VEL * m_decelerator.get(m_driver.getRawAxis(3)),
+                                deadband(-m_driver.getLeftX()) * MAX_VEL * m_decelerator.get(m_driver.getRawAxis(3)
                                 )
                         ),
                         angleChooser::getSelected
                 ));
     }
 
-    /**
-     * Use this to pass the autonomous command to the main {@link Robot} class.
-     *
-     * @return the command to run in autonomous
-     */
+
     public Command getAutonomousCommand() {
         return m_autoChooser.getSelected();
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -95,7 +95,9 @@ public class RobotContainer implements Logged {
                 ),
                 () -> new Rotation2d(Math.PI)/*Rotation2d.fromDegrees(angleEntry.getDouble(0))*/));
 
-        driver.cross().onTrue(m_swerve.driveToPoseCommand(new Pose2d(0, 0, new Rotation2d(Math.PI / 2))));
+        driver.cross().onTrue(m_swerve.driveToPoseCommand(new Pose2d(1, 1, new Rotation2d(Math.PI / 2))));
+
+        driver.square().onTrue(m_swerve.pathfindThenFollowPathCommand("testPath2"));
     }
 
     public double deadband(double value) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,7 +13,9 @@ import com.pathplanner.lib.events.PointTowardsZoneTrigger;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.interpolation.InterpolatingDoubleTreeMap;
+import edu.wpi.first.wpilibj.BuiltInAccelerometer;
 import edu.wpi.first.wpilibj.PowerDistribution;
+import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
@@ -25,6 +27,7 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 import frc.excalib.control.math.Vector2D;
 import frc.excalib.swerve.Swerve;
+import monologue.Annotations;
 import monologue.Logged;
 
 import static edu.wpi.first.wpilibj2.command.Command.InterruptionBehavior.kCancelIncoming;
@@ -38,6 +41,7 @@ import static frc.robot.Constants.SwerveConstants.*;
  * subsystems, commands, and trigger mappings) should be declared here.
  */
 public class RobotContainer implements Logged {
+    private final BuiltInAccelerometer accelerometer = new BuiltInAccelerometer();
     // The robot's subsystems and commands are defined here...
 
     private final Swerve m_swerve = configureSwerve(new Pose2d());
@@ -49,6 +53,8 @@ public class RobotContainer implements Logged {
     public Runnable updateOdometry = m_swerve::updateOdometry;
 
     private SendableChooser<Command> m_autoChooser;
+
+    private final BuiltInAccelerometer m_accelerometer = new BuiltInAccelerometer();
 
     /**
      * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -104,14 +110,14 @@ public class RobotContainer implements Logged {
     }
 
     public double deadband(double value) {
-        return Math.abs(value) < 0.1 ? 0 : value;
+        return Math.abs(value) < 0.15 ? 0 : value;
     }
 
     private void initAutoChooser() {
         NamedCommands.registerCommand("print command", new PrintCommand("pathplanner"));
 
-        new EventTrigger("testTrigger").whileTrue(Commands.run(()->System.out.println("Trigger Test")));
-        new PointTowardsZoneTrigger("PointTowardsZoneTrigger").whileTrue(Commands.run(()->System.out.println("Trigger Test😎")));
+        new EventTrigger("testTrigger").whileTrue(Commands.run(() -> System.out.println("Trigger Test")));
+        new PointTowardsZoneTrigger("PointTowardsZoneTrigger").whileTrue(Commands.run(() -> System.out.println("Trigger Test2")));
 
         // Build an auto chooser. This will use Commands.none() as the default option.
         m_autoChooser = AutoBuilder.buildAutoChooser();
@@ -150,6 +156,11 @@ public class RobotContainer implements Logged {
                         ),
                         angleChooser::getSelected
                 ));
+    }
+
+    @Annotations.Log.NT
+    public double getAcc() {
+        return Math.sqrt(Math.pow(m_accelerometer.getX(), 2) + Math.pow(m_accelerometer.getY(), 2)) * 9.8;
     }
 
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -86,6 +86,7 @@ public class RobotContainer implements Logged {
         driver.cross().onTrue(
                 m_swerve.driveToPoseWithOverrideCommand(
                         new Pose2d(1, 0, new Rotation2d()),
+                        driver.R2(),
                         () -> new Vector2D(
                                 deadband(-driver.getLeftY()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3)),
                                 deadband(-driver.getLeftX()) * MAX_VEL * m_decelerator.get(driver.getRawAxis(3))),

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,6 +7,9 @@ package frc.robot;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;
 import com.pathplanner.lib.commands.PathPlannerAuto;
+import com.pathplanner.lib.events.EventTrigger;
+import com.pathplanner.lib.events.PointTowardsZoneEvent;
+import com.pathplanner.lib.events.PointTowardsZoneTrigger;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.interpolation.InterpolatingDoubleTreeMap;
@@ -107,12 +110,17 @@ public class RobotContainer implements Logged {
     private void initAutoChooser() {
         NamedCommands.registerCommand("print command", new PrintCommand("pathplanner"));
 
+        new EventTrigger("testTrigger").whileTrue(Commands.run(()->System.out.println("Trigger Test")));
+        new PointTowardsZoneTrigger("PointTowardsZoneTrigger").whileTrue(Commands.run(()->System.out.println("Trigger Test😎")));
+
         // Build an auto chooser. This will use Commands.none() as the default option.
         m_autoChooser = AutoBuilder.buildAutoChooser();
         m_autoChooser.addOption("Test Auto", new PathPlannerAuto("testAuto"));
         m_autoChooser.addOption("Test Auto 2", new PathPlannerAuto("testAuto2"));
         m_autoChooser.addOption("Calibration Auto", new PathPlannerAuto("calibrationAuto"));
         m_autoChooser.addOption("Test Choreo Auto", new PathPlannerAuto("testChoreoAuto"));
+        m_autoChooser.addOption("Test Trigger", new PathPlannerAuto("triggerTest"));
+        m_autoChooser.addOption("Heart", new PathPlannerAuto("HeartAuto"));
 
         // Another option that allows you to specify the default auto by its name
         // autoChooser = AutoBuilder.buildAutoChooser("My Default Auto");


### PR DESCRIPTION
This pull request includes significant changes to the `elastic-layout.json` file and the addition of several new auto and path files in the `pathplanner` directory. The most important changes include the removal of the "Drive To Pose" layout, modifications to the "Field" and "swerve info" layouts, and the addition of new auto and path configurations.

Changes to `elastic-layout.json`:

* Removed the "Drive To Pose" layout and its child elements.
* Modified the "Field" layout's position and size.
* Renamed and repositioned the "X" layout to "swerve info" and added a new "Command Scheduler" layout.

Additions to `pathplanner` autos:

* Added `HeartAuto.auto` with a sequential command for the "HeartPath".
* Added `New Auto.auto` with multiple sequential path commands.
* Updated `calibrationAuto.auto`, `testAuto.auto`, `testAuto2.auto`, and `testChoreoAuto.auto` to include the "test and calibration autos" folder. [[1]](diffhunk://#diff-5eb84492160effc5c236093c0a46c1a5ccd0238568c147cf74aaee83164f4dcbL17-R17) [[2]](diffhunk://#diff-25fad1979d363565cda7fc6bcd7ac8488dfbb41b67e74d6b37ab3845bfc23080L30-R30) [[3]](diffhunk://#diff-8b84159a7325103614bfd6adcffad033b98d3f7328638c999e71ccf1d73a10fbL29-R29) [[4]](diffhunk://#diff-8ee070f8e98ca2112b8ffad975d080b10b3f00cfbe1e0c1aaaa286b501c18450L17-R17)
* Added `triggerTest.auto` with a sequential command for the "trigger test" path.

Additions to `pathplanner` paths:

* Added new paths: `B2F.path`, `B4F.path`, `B5F.path`, `C3B1.path`, `C3B2.path`, `C3L1F.path`, `FB4.path`, `FB5.path`, and `FB6.path`. [[1]](diffhunk://#diff-b67f79f7dcf6fec443e0c7a9de3dc582a4dd07400f4d07bd9a5d93f6b8a37266R1-R54) [[2]](diffhunk://#diff-dfced6c890b5e0d679bc637211342d0a5f05bb00d9997526ac9786e491f6f24dR1-R54) [[3]](diffhunk://#diff-6482e34771a7528dc6755837991024c5a76f954e6069dee782bdbd65b4d0438dR1-R54) [[4]](diffhunk://#diff-97f876cf08f6c0f02bbccbf92c4ad417291333cd43015cf62fa5bd42ecc2ef21R1-R54) [[5]](diffhunk://#diff-690e02e7f7026ee5f3a5c28a5924e2686547ae94f71500c57119ff26412b7da5R1-R54) [[6]](diffhunk://#diff-1e858260009dcc7b4d9930c8eca592fd6340fd9b4412879958e1ed92e93aaefcR1-R93) [[7]](diffhunk://#diff-e05b07a4481a472bab34e9144ba297eb871d1be5460290dadc0ac3bb73479170R1-R54) [[8]](diffhunk://#diff-4e0347626bd10ccb9a7688ec127a760fa2c056ddf812bba9f67444e64264cae5R1-R54) [[9]](diffhunk://#diff-3ef37ab1ca8569cb17953f1a916f6840f463717e712755d0e5a23ad425529c8cR1-R59)