### PR TITLE
Leds expand

### DIFF
--- a/src/main/java/frc/excalib/additional_utilities/LEDs.java
+++ b/src/main/java/frc/excalib/additional_utilities/LEDs.java
@@ -40,7 +40,7 @@ public class LEDs extends SubsystemBase {
         Arrays.fill(orange, ORANGE.color);
         Arrays.fill(black, OFF.color);
 
-        setDefaultCommand(setPattern(LEDPattern.TRAIN_CIRCLE, BLUE.color, TEAM_GOLD.color));
+        setDefaultCommand(setPattern(LEDPattern.EXPAND, BLUE.color, TEAM_GOLD.color));
 //        setDefaultCommand(setPattern(LEDPattern.RSL, BLUE.color, TEAM_GOLD.color));
     }
 
@@ -128,29 +128,36 @@ public class LEDs extends SubsystemBase {
                 command = new InstantCommand(() -> {
                     Color[] LedColors = new Color[LENGTH];
                     Arrays.fill(LedColors, mainColor);
+                    int LEDS_LENGTH = 5;
+
+                    int step = expandStep.get();
 
                     if (LENGTH % 2 == 0) {
                         int leftCenter = (LENGTH / 2) - 1;
                         int rightCenter = LENGTH / 2;
-                        int step = expandStep.get();
                         int leftIndex = leftCenter - step;
                         int rightIndex = rightCenter + step;
-                        if (leftIndex >= 0) {
-                            LedColors[leftIndex] = accentColor;
-                        }
-                        if (rightIndex < LENGTH) {
-                            LedColors[rightIndex] = accentColor;
+
+                        for (int i = 0; i < LEDS_LENGTH; i++) { // Light up 3 LEDs per side
+                            if (leftIndex - i >= 0) {
+                                LedColors[leftIndex - i] = accentColor;
+                            }
+                            if (rightIndex + i < LENGTH) {
+                                LedColors[rightIndex + i] = accentColor;
+                            }
                         }
                     } else {
                         int center = LENGTH / 2;
-                        int step = expandStep.get();
                         int leftIndex = center - step;
                         int rightIndex = center + step;
-                        if (leftIndex >= 0) {
-                            LedColors[leftIndex] = accentColor;
-                        }
-                        if (rightIndex < LENGTH) {
-                            LedColors[rightIndex] = accentColor;
+
+                        for (int i = 0; i < LEDS_LENGTH; i++) { // Light up 3 LEDs per side
+                            if (leftIndex - i >= 0) {
+                                LedColors[leftIndex - i] = accentColor;
+                            }
+                            if (rightIndex + i < LENGTH) {
+                                LedColors[rightIndex + i] = accentColor;
+                            }
                         }
                     }
 
@@ -162,7 +169,7 @@ public class LEDs extends SubsystemBase {
 
                     setLedStrip(LedColors);
                 }, this)
-                        .andThen(new WaitCommand(0.1))
+                        .andThen(new WaitCommand(0.01))
                         .repeatedly()
                         .withName("EXPAND, main: " + mainColor.toString() + ", accent: " + accentColor.toString());
                 break;

--- a/src/main/java/frc/excalib/additional_utilities/LEDs.java
+++ b/src/main/java/frc/excalib/additional_utilities/LEDs.java
@@ -123,6 +123,50 @@ public class LEDs extends SubsystemBase {
                 ).withName("BLINKING, main: " + mainColor.toString() + ", accent: " + accentColor.toString());
                 break;
 
+            case EXPAND:
+                final AtomicInteger expandStep = new AtomicInteger(0);
+                command = new InstantCommand(() -> {
+                    Color[] LedColors = new Color[LENGTH];
+                    Arrays.fill(LedColors, mainColor);
+
+                    if (LENGTH % 2 == 0) {
+                        int leftCenter = (LENGTH / 2) - 1;
+                        int rightCenter = LENGTH / 2;
+                        int step = expandStep.get();
+                        int leftIndex = leftCenter - step;
+                        int rightIndex = rightCenter + step;
+                        if (leftIndex >= 0) {
+                            LedColors[leftIndex] = accentColor;
+                        }
+                        if (rightIndex < LENGTH) {
+                            LedColors[rightIndex] = accentColor;
+                        }
+                    } else {
+                        int center = LENGTH / 2;
+                        int step = expandStep.get();
+                        int leftIndex = center - step;
+                        int rightIndex = center + step;
+                        if (leftIndex >= 0) {
+                            LedColors[leftIndex] = accentColor;
+                        }
+                        if (rightIndex < LENGTH) {
+                            LedColors[rightIndex] = accentColor;
+                        }
+                    }
+
+                    int newStep = expandStep.get() + 1;
+                    if (newStep > (LENGTH / 2)) {
+                        newStep = 0;
+                    }
+                    expandStep.set(newStep);
+
+                    setLedStrip(LedColors);
+                }, this)
+                        .andThen(new WaitCommand(0.1))
+                        .repeatedly()
+                        .withName("EXPAND, main: " + mainColor.toString() + ", accent: " + accentColor.toString());
+                break;
+
             case TRAIN:
                 command = new InstantCommand(() -> {
                     Arrays.fill(colors, mainColor);
@@ -160,9 +204,9 @@ public class LEDs extends SubsystemBase {
                 });
 
             case RSL:
-                command = new RunCommand(() ->{
-                    setLedStrip(RobotController.getRSLState()? orange : black);
-                } , this).withName("SOLID: " + mainColor.toString());
+                command = new RunCommand(() -> {
+                    setLedStrip(RobotController.getRSLState() ? orange : black);
+                }, this).withName("SOLID: " + mainColor.toString());
 
             default:
                 break;


### PR DESCRIPTION
This pull request includes updates to the LED pattern functionality in the `LEDs` class. The most significant changes involve adding a new LED pattern called `EXPAND` and updating the default command to use this new pattern.

### LED Pattern Updates:

* [`src/main/java/frc/excalib/additional_utilities/LEDs.java`](diffhunk://#diff-2dba342a09819368a7dcd95ee176baed65988acc2536fdeb9f1ae6aa595351e2L43-R43): Updated the default LED pattern from `TRAIN_CIRCLE` to `EXPAND`.
* [`src/main/java/frc/excalib/additional_utilities/LEDs.java`](diffhunk://#diff-2dba342a09819368a7dcd95ee176baed65988acc2536fdeb9f1ae6aa595351e2R126-R176): Added the implementation for the new `EXPAND` LED pattern, which lights up LEDs in an expanding pattern from the center.