### PR TITLE
District Championship

### DIFF
--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -62,7 +62,7 @@
             }
           },
           {
-            "title": "Match Time",
+            "title": "match time",
             "x": 0.0,
             "y": 0.0,
             "width": 640.0,
@@ -78,7 +78,7 @@
             }
           },
           {
-            "title": "Camera",
+            "title": "orangepi_Port_1184_Output_MJPEG_Server",
             "x": 896.0,
             "y": 0.0,
             "width": 640.0,
@@ -91,7 +91,7 @@
             }
           },
           {
-            "title": "Current Reef Slice",
+            "title": "getReefSlice",
             "x": 0.0,
             "y": 384.0,
             "width": 384.0,
@@ -138,7 +138,7 @@
             }
           },
           {
-            "title": "State",
+            "title": "getCurrentRobotNamedSate",
             "x": 0.0,
             "y": 512.0,
             "width": 384.0,
@@ -151,7 +151,7 @@
             }
           },
           {
-            "title": "Target Reef Slice",
+            "title": "getTragetSlice",
             "x": 384.0,
             "y": 384.0,
             "width": 384.0,
@@ -181,7 +181,7 @@
             }
           },
           {
-            "title": "Back Camera",
+            "title": "orangepi_Port_1182_Output_MJPEG_Server",
             "x": 1280.0,
             "y": 640.0,
             "width": 256.0,
@@ -191,6 +191,19 @@
               "topic": "/CameraPublisher/orangepi_Port_1182_Output_MJPEG_Server",
               "period": 0.06,
               "rotation_turns": 0
+            }
+          },
+          {
+            "title": "autoChooser",
+            "x": 896.0,
+            "y": 640.0,
+            "width": 384.0,
+            "height": 128.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/autoChooser",
+              "period": 0.06,
+              "sort_options": false
             }
           }
         ]
@@ -219,19 +232,6 @@
               "field_rotation": 0.0,
               "robot_color": 4278264421,
               "trajectory_color": 4292128567
-            }
-          },
-          {
-            "title": "Auto Chooser",
-            "x": 0.0,
-            "y": 0.0,
-            "width": 256.0,
-            "height": 128.0,
-            "type": "ComboBox Chooser",
-            "properties": {
-              "topic": "/SmartDashboard/Auto Chooser",
-              "period": 0.06,
-              "sort_options": true
             }
           }
         ]

--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -22,7 +22,7 @@
               "robot_length": 0.85,
               "show_other_objects": true,
               "show_trajectories": true,
-              "field_rotation": 90.0,
+              "field_rotation": -90.0,
               "robot_color": 4294901760,
               "trajectory_color": 4294967295
             }
@@ -65,7 +65,7 @@
             "title": "match time",
             "x": 0.0,
             "y": 0.0,
-            "width": 640.0,
+            "width": 384.0,
             "height": 384.0,
             "type": "Match Time",
             "properties": {
@@ -141,7 +141,7 @@
             "title": "getTragetSlice",
             "x": 384.0,
             "y": 384.0,
-            "width": 384.0,
+            "width": 512.0,
             "height": 128.0,
             "type": "Large Text Display",
             "properties": {
@@ -216,6 +216,40 @@
                 800.0,
                 600.0
               ]
+            }
+          },
+          {
+            "title": "getTagTimer",
+            "x": 384.0,
+            "y": 0.0,
+            "width": 256.0,
+            "height": 256.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/Robot/m_swerve/m_frontCamera/getTagTimer",
+              "period": 0.06,
+              "data_type": "boolean",
+              "true_color": 4283215696,
+              "false_color": 4294198070,
+              "true_icon": "None",
+              "false_icon": "None"
+            }
+          },
+          {
+            "title": "atNetPose",
+            "x": 384.0,
+            "y": 256.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Boolean Box",
+            "properties": {
+              "topic": "/Robot/atNetPose",
+              "period": 0.06,
+              "data_type": "boolean",
+              "true_color": 4283215696,
+              "false_color": 4294198070,
+              "true_icon": "None",
+              "false_icon": "None"
             }
           }
         ]

--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -78,19 +78,6 @@
             }
           },
           {
-            "title": "orangepi_Port_1184_Output_MJPEG_Server",
-            "x": 896.0,
-            "y": 0.0,
-            "width": 640.0,
-            "height": 512.0,
-            "type": "Camera Stream",
-            "properties": {
-              "topic": "/CameraPublisher/orangepi_Port_1184_Output_MJPEG_Server",
-              "period": 0.06,
-              "rotation_turns": 0
-            }
-          },
-          {
             "title": "getReefSlice",
             "x": 0.0,
             "y": 384.0,
@@ -190,7 +177,13 @@
             "properties": {
               "topic": "/CameraPublisher/orangepi_Port_1182_Output_MJPEG_Server",
               "period": 0.06,
-              "rotation_turns": 0
+              "rotation_turns": 0,
+              "compression": 39,
+              "fps": 30,
+              "resolution": [
+                800.0,
+                600.0
+              ]
             }
           },
           {
@@ -204,6 +197,25 @@
               "topic": "/SmartDashboard/autoChooser",
               "period": 0.06,
               "sort_options": false
+            }
+          },
+          {
+            "title": "orangepi_Port_1184_Output_MJPEG_Server",
+            "x": 896.0,
+            "y": 0.0,
+            "width": 640.0,
+            "height": 512.0,
+            "type": "Camera Stream",
+            "properties": {
+              "topic": "/CameraPublisher/orangepi_Port_1184_Output_MJPEG_Server",
+              "period": 0.06,
+              "rotation_turns": 0,
+              "compression": 29,
+              "fps": 30,
+              "resolution": [
+                800.0,
+                600.0
+              ]
             }
           }
         ]

--- a/src/main/java/frc/excalib/slam/mapper/PhotonAprilTagsCamera.java
+++ b/src/main/java/frc/excalib/slam/mapper/PhotonAprilTagsCamera.java
@@ -32,14 +32,18 @@ public class PhotonAprilTagsCamera implements Logged {
     private final double TOO_FAR = 3.5; // m
     private final double TOO_LONG = 3; // s
     private final Timer tagTimer = new Timer();
+    private final Timer tagTimerHigh = new Timer();
     private final Trigger seenTrigger;
+    private final Trigger seenTriggerHigh;
 
     public PhotonAprilTagsCamera(String cameraName, AprilTagFields aprilTagField, Transform3d robotToCamera) {
         m_camera = new PhotonCamera(cameraName);
         m_camera.setDriverMode(false);
 
         tagTimer.start();
+        tagTimerHigh.start();
         seenTrigger = new Trigger(()-> tagTimer.get() < TOO_LONG);
+        seenTriggerHigh = new Trigger(()-> tagTimerHigh.get() < TOO_LONG);
 
         m_fieldLayout = AprilTagFieldLayout.loadField(aprilTagField);
 
@@ -99,6 +103,10 @@ public class PhotonAprilTagsCamera implements Logged {
     @Log.NT
     public boolean getTagTimer(){
         return seenTrigger.getAsBoolean();
+    }
+    @Log.NT
+    public boolean getTagTimerHigh(){
+        return seenTriggerHigh.getAsBoolean();
     }
 }
 

--- a/src/main/java/frc/excalib/slam/mapper/PhotonAprilTagsCamera.java
+++ b/src/main/java/frc/excalib/slam/mapper/PhotonAprilTagsCamera.java
@@ -5,6 +5,11 @@ import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import monologue.Annotations;
+import monologue.Annotations.Log;
+import monologue.Logged;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonPoseEstimator;
@@ -16,7 +21,7 @@ import java.util.function.BiConsumer;
 import static org.photonvision.PhotonPoseEstimator.PoseStrategy.LOWEST_AMBIGUITY;
 import static org.photonvision.PhotonPoseEstimator.PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR;
 
-public class PhotonAprilTagsCamera {
+public class PhotonAprilTagsCamera implements Logged {
     private final PhotonCamera m_camera;
     private final AprilTagFieldLayout m_fieldLayout;
 
@@ -24,11 +29,17 @@ public class PhotonAprilTagsCamera {
 
     private final Transform3d kRobotToCamera;
 
-    private final double TOO_FAR = 3.5; //m
+    private final double TOO_FAR = 3.5; // m
+    private final double TOO_LONG = 3; // s
+    private final Timer tagTimer = new Timer();
+    private final Trigger seenTrigger;
 
     public PhotonAprilTagsCamera(String cameraName, AprilTagFields aprilTagField, Transform3d robotToCamera) {
         m_camera = new PhotonCamera(cameraName);
         m_camera.setDriverMode(false);
+
+        tagTimer.start();
+        seenTrigger = new Trigger(()-> tagTimer.get() < TOO_LONG);
 
         m_fieldLayout = AprilTagFieldLayout.loadField(aprilTagField);
 
@@ -62,6 +73,7 @@ public class PhotonAprilTagsCamera {
         if (result.hasTargets() && result.getBestTarget().getPoseAmbiguity() < 0.2) {
             Translation2d targetTranslation = result.getBestTarget().getBestCameraToTarget().getTranslation().toTranslation2d();
             if (targetTranslation.getDistance(new Translation2d(0, 0)) < TOO_FAR) {
+                tagTimer.restart();
                 m_photonPoseEstimator.setReferencePose(prevEstimatedRobotPose);
                 return m_photonPoseEstimator.update(result);
             }
@@ -82,6 +94,11 @@ public class PhotonAprilTagsCamera {
 
         toUpdate.accept(tag.get().plus(result.getBestTarget().getBestCameraToTarget()).toPose2d(), result.getTimestampSeconds());
         return true;
+    }
+
+    @Log.NT
+    public boolean getTagTimer(){
+        return seenTrigger.getAsBoolean();
     }
 }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -46,7 +46,7 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void robotPeriodic() {
-        Monologue.setFileOnly(DriverStation.isFMSAttached());
+//        Monologue.setFileOnly(DriverStation.isFMSAttached());
         Monologue.updateAll();
         CommandScheduler.getInstance().run();
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -54,7 +54,7 @@ public class RobotContainer implements Logged {
     private final Automations m_automations;
 
 
-    private SendableChooser<Command> m_autoChooser;
+    private SendableChooser<Command> m_autoChooser = new SendableChooser<>();
 
     public RobotContainer() {
         m_decelerator.put(-1.0, 1.0);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -114,17 +114,24 @@ public class RobotContainer implements Logged {
         m_driver.R1().onTrue(m_automations.changeRightSlice());
         m_driver.L1().onTrue(m_automations.changeLeftSlice());
 
-        m_operator.R1().onTrue(new InstantCommand(() -> this.right = true));
-        m_operator.L1().onTrue(new InstantCommand(() -> this.right = false));
+//        ][\
+//
+//
+//
+//     .R1().onTrue(new InstantCommand(() -> this.right = true).ignoringDisable(true));
+        m_operator.L1().onTrue(new InstantCommand(() -> this.right = false).ignoringDisable(true));
 
         m_operator.circle().onTrue(m_superstructure.ejectAlgaeCommand());
         m_operator.triangle().onTrue(m_superstructure.startAutomationCommand());
         m_operator.povDown().onTrue(m_superstructure.scoreAlgaeCommand(PROCESSOR_ID));
+        m_operator.povUp().toggleOnTrue(m_superstructure.alignToAlgaeCommand(NET_ID));
+        m_operator.create().toggleOnTrue(m_superstructure.scoreAlgaeCommand());
+
+        m_operator.R2().toggleOnTrue(m_superstructure.intakeCoralCommand().andThen(new WaitUntilCommand(m_superstructure.hasCoralTrigger())).andThen(m_superstructure.collapseCommand()));
 
         m_operator.square().onTrue(m_automations.cancelAutomationCommand());
 
-        m_operator.touchpad().whileTrue(m_superstructure.coastCommand().alongWith(m_swerve.coastCommand()).ignoringDisable(true));
-    }
+        m_operator.touchpad().whileTrue(m_superstructure.coastCommand().alongWith(m_swerve.coastCommand()).ignoringDisable(true));}
 
 
     public double deadband(double value) {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -118,7 +118,7 @@ public class RobotContainer implements Logged {
 //
 //
 //
-//     .R1().onTrue(new InstantCommand(() -> this.right = true).ignoringDisable(true));
+        m_operator.R1().onTrue(new InstantCommand(() -> this.right = true).ignoringDisable(true));
         m_operator.L1().onTrue(new InstantCommand(() -> this.right = false).ignoringDisable(true));
 
         m_operator.circle().onTrue(m_superstructure.ejectAlgaeCommand());
@@ -236,5 +236,10 @@ public class RobotContainer implements Logged {
     @Log.NT
     public boolean atAutoMode() {
         return m_automations.m_autoMode.getAsBoolean();
+    }
+
+    @Log.NT
+    public boolean atNetPose(){
+        return m_automations.atNetPose();
     }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -124,14 +124,17 @@ public class RobotContainer implements Logged {
         m_operator.circle().onTrue(m_superstructure.ejectAlgaeCommand());
         m_operator.triangle().onTrue(m_superstructure.startAutomationCommand());
         m_operator.povDown().onTrue(m_superstructure.scoreAlgaeCommand(PROCESSOR_ID));
+
+        m_operator.povRight().toggleOnTrue(m_automations.netCommand());
+
         m_operator.povUp().toggleOnTrue(m_superstructure.alignToAlgaeCommand(NET_ID));
         m_operator.create().toggleOnTrue(m_superstructure.scoreAlgaeCommand());
 
         m_operator.R2().toggleOnTrue(m_superstructure.intakeCoralCommand().andThen(new WaitUntilCommand(m_superstructure.hasCoralTrigger())).andThen(m_superstructure.collapseCommand()));
-
         m_operator.square().onTrue(m_automations.cancelAutomationCommand());
 
-        m_operator.touchpad().whileTrue(m_superstructure.coastCommand().alongWith(m_swerve.coastCommand()).ignoringDisable(true));}
+        m_operator.touchpad().whileTrue(m_superstructure.coastCommand().alongWith(m_swerve.coastCommand()).ignoringDisable(true));
+    }
 
 
     public double deadband(double value) {
@@ -143,7 +146,11 @@ public class RobotContainer implements Logged {
                 m_automations.toggleAutoMode(),
                 new WaitUntilCommand(m_automations.m_atTargetSlicePose),
                 m_automations.L4Command(false),
-                m_superstructure.collapseCommand()
+                new WaitUntilCommand(m_automations.m_atTargetSlicePose),
+                m_automations.intakeAlgaeCommand(),
+                m_automations.toggleAutoMode(),
+                m_automations.netCommand()
+
         );
 
         Command leftAutoCommand = new SequentialCommandGroup(
@@ -174,11 +181,22 @@ public class RobotContainer implements Logged {
                 m_superstructure.collapseCommand()
         );
 
+        Command l4WithNet = new SequentialCommandGroup(
+                m_automations.toggleAutoMode(),
+                new WaitUntilCommand(m_automations.m_atTargetSlicePose),
+                m_automations.L4Command(true),
+                new WaitUntilCommand(m_automations.m_atTargetSlicePose),
+                m_automations.intakeAlgaeCommand(),
+                new WaitUntilCommand(m_automations.m_atTargetSlicePose),
+                m_automations.netCommand()
+        );
+
         m_autoChooser.setDefaultOption("empty auto", new InstantCommand());
         m_autoChooser.addOption("exit from line", m_swerve.driveCommand(() -> new Vector2D(1, 0), () -> 0, () -> false).withTimeout(2));
         m_autoChooser.addOption("center auto", centerAutoCommand);
         m_autoChooser.addOption("left auto", leftAutoCommand);
         m_autoChooser.addOption("right auto", rightAutoCommand);
+        m_autoChooser.addOption("1 L4 with Net", rightAutoCommand);
 
         SmartDashboard.putData("autoChooser", m_autoChooser);
     }
@@ -239,7 +257,7 @@ public class RobotContainer implements Logged {
     }
 
     @Log.NT
-    public boolean atNetPose(){
+    public boolean atNetPose() {
         return m_automations.atNetPose();
     }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -54,7 +54,7 @@ public class RobotContainer implements Logged {
     private final Automations m_automations;
 
 
-    private SendableChooser<Command> m_autoChooser = new SendableChooser<>();
+    public SendableChooser<Command> m_autoChooser = new SendableChooser<>();
 
     public RobotContainer() {
         m_decelerator.put(-1.0, 1.0);
@@ -62,7 +62,7 @@ public class RobotContainer implements Logged {
         m_automations = new Automations(m_swerve, m_superstructure);
 
 
-//        initAutoChooser();
+        initAutoChooser();
         initElastic();
 
         // Configure the trigger bindings
@@ -173,7 +173,7 @@ public class RobotContainer implements Logged {
         m_autoChooser.addOption("left auto", leftAutoCommand);
         m_autoChooser.addOption("right auto", rightAutoCommand);
 
-        SmartDashboard.putData("auto chooser", m_autoChooser);
+        SmartDashboard.putData("autoChooser", m_autoChooser);
     }
 
     private void initElastic() {

--- a/src/main/java/frc/robot/automations/Automations.java
+++ b/src/main/java/frc/robot/automations/Automations.java
@@ -26,7 +26,7 @@ public class Automations {
     public final Trigger m_atTargetSlicePose;
     private boolean autoMode = false;
     public final Trigger m_autoMode = new Trigger(() -> autoMode);
-    private final Trigger atNetPoseTrigger = new Trigger(() -> Math.abs(m_swerve.getPose2D().getX() - NET_X_VALUE) < 0.01);
+    private final Trigger atNetPoseTrigger = new Trigger(() -> Math.abs(m_swerve.getPose2D().getX() - NET_X_VALUE) < 0.03);
 
     public Automations(Swerve swerve, Superstructure superstructure) {
         this.m_superstructure = superstructure;

--- a/src/main/java/frc/robot/automations/Constants.java
+++ b/src/main/java/frc/robot/automations/Constants.java
@@ -24,11 +24,12 @@ public final class Constants {
             return RED_REEF_CENTER;
         }
 
-        private static final Translation2d B1 = new Translation2d(5.7668696, 3.812), B12 = new Translation2d(5.7668696, 4.142);
+        private static final Translation2d B1 = new Translation2d(5.7668696, 3.812+0.02), B12 = new Translation2d(5.7668696, 4.142+0.02);
         private static final Translation2d BASE_L1 = new Translation2d(5.7668696, 4.0259);
-        private static final Translation2d BASE_ALGAE = new Translation2d(5.7668696, 4.0259); //TODO: find x
-        private static final Translation2d BASE_POST_ALGAE = new Translation2d(6.3, 4.0259); //TODO: find x
+        private static final Translation2d BASE_ALGAE = new Translation2d(5.7668696, 4.0259+0.02); //TODO: find x
+        private static final Translation2d BASE_POST_ALGAE = new Translation2d(6.3, 4.0259+0.02); //TODO: find x
         private static final Translation2d BASE_GENERAL = new Translation2d(6.3, 4.0259);
+        private static final double NET_X_VALUE = 7.718;
 
         public static AlliancePose[] GENERAL_POSES = {
                 new AlliancePose(BASE_GENERAL, Rotation2d.fromDegrees(180)),
@@ -83,7 +84,6 @@ public final class Constants {
         };
         //
         public static final AlliancePose[] FEEDERS_POSES = {
-//                new AlliancePose(new Translation2d(1.02, 0.92), new Rotation2d(Units.degreesToRadians(54))),
                 new AlliancePose(new Translation2d(0.91, FIELD_WIDTH_METERS - 6.96), new Rotation2d(Units.degreesToRadians(54))),
                 new AlliancePose(new Translation2d(1.12, FIELD_WIDTH_METERS - 7.02), new Rotation2d(Units.degreesToRadians(54))),
                 new AlliancePose(new Translation2d(1.25, FIELD_WIDTH_METERS - 7.19), new Rotation2d(Units.degreesToRadians(54))),
@@ -91,12 +91,15 @@ public final class Constants {
                 new AlliancePose(new Translation2d(1.12, 7.02), new Rotation2d(Units.degreesToRadians(306))),
                 new AlliancePose(new Translation2d(1.25, 7.19), new Rotation2d(Units.degreesToRadians(306)))
         };
-//
-//        public static final Pose2d[] NET_POSES = {
-//                new Pose2d(),
-//                new Pose2d(),
-//                new Pose2d()
-//        };
-//
+
+        public static final AlliancePose[] NET_POSES = {
+                new AlliancePose(NET_X_VALUE, 7.5, 0),
+                new AlliancePose(NET_X_VALUE, 7.0, 0),
+                new AlliancePose(NET_X_VALUE, 6.5, 0),
+                new AlliancePose(NET_X_VALUE, 5, 0),
+                new AlliancePose(NET_X_VALUE, 5.5, 0),
+                new AlliancePose(NET_X_VALUE, 5, 0)
+        };
+
     }
 }

--- a/src/main/java/frc/robot/automations/Constants.java
+++ b/src/main/java/frc/robot/automations/Constants.java
@@ -26,10 +26,10 @@ public final class Constants {
 
         private static final Translation2d B1 = new Translation2d(5.7668696, 3.812+0.02), B12 = new Translation2d(5.7668696, 4.142+0.02);
         private static final Translation2d BASE_L1 = new Translation2d(5.7668696, 4.0259);
-        private static final Translation2d BASE_ALGAE = new Translation2d(5.7668696, 4.0259+0.02); //TODO: find x
-        private static final Translation2d BASE_POST_ALGAE = new Translation2d(6.3, 4.0259+0.02); //TODO: find x
+        private static final Translation2d BASE_ALGAE = new Translation2d(5.7668696, 4.0259-0.02); //TODO: find x
+        private static final Translation2d BASE_POST_ALGAE = new Translation2d(6.3, 4.0259-0.02); //TODO: find x
         private static final Translation2d BASE_GENERAL = new Translation2d(6.3, 4.0259);
-        private static final double NET_X_VALUE = 7.718;
+        public static final double NET_X_VALUE = 7.718;
 
         public static AlliancePose[] GENERAL_POSES = {
                 new AlliancePose(BASE_GENERAL, Rotation2d.fromDegrees(180)),

--- a/src/main/java/frc/robot/automations/Constants.java
+++ b/src/main/java/frc/robot/automations/Constants.java
@@ -5,6 +5,8 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.util.Units;
 import frc.excalib.additional_utilities.AllianceUtils;
 
+import javax.swing.plaf.PanelUI;
+
 import static frc.excalib.additional_utilities.AllianceUtils.*;
 
 public final class Constants {
@@ -29,7 +31,8 @@ public final class Constants {
         private static final Translation2d BASE_ALGAE = new Translation2d(5.7668696, 4.0259-0.02); //TODO: find x
         private static final Translation2d BASE_POST_ALGAE = new Translation2d(6.3, 4.0259-0.02); //TODO: find x
         private static final Translation2d BASE_GENERAL = new Translation2d(6.3, 4.0259);
-        public static final double NET_X_VALUE = 7.718;
+        public static final double NET_X_VALUE = 7.721;
+        public static final double POST_NET_X_VALUE = 7.418;
 
         public static AlliancePose[] GENERAL_POSES = {
                 new AlliancePose(BASE_GENERAL, Rotation2d.fromDegrees(180)),
@@ -99,6 +102,14 @@ public final class Constants {
                 new AlliancePose(NET_X_VALUE, 5, 0),
                 new AlliancePose(NET_X_VALUE, 5.5, 0),
                 new AlliancePose(NET_X_VALUE, 5, 0)
+        };
+        public static final AlliancePose[] POST_NET_POSES = {
+                new AlliancePose(POST_NET_X_VALUE, 7.5, 0),
+                new AlliancePose(POST_NET_X_VALUE, 7.0, 0),
+                new AlliancePose(POST_NET_X_VALUE, 6.5, 0),
+                new AlliancePose(POST_NET_X_VALUE, 5, 0),
+                new AlliancePose(POST_NET_X_VALUE, 5.5, 0),
+                new AlliancePose(POST_NET_X_VALUE, 5, 0)
         };
 
     }

--- a/src/main/java/frc/robot/superstructure/Constants.java
+++ b/src/main/java/frc/robot/superstructure/Constants.java
@@ -47,19 +47,19 @@ public class Constants {
     public static final double POST_L2_ALGAE_WHEELS_VOLTAGE = 3;
 
     // PRE L3 Constants TODO
-    public static final double PRE_L3_ELEVATOR_HEIGHT = 0.0794 + 0.04;
+    public static final double PRE_L3_ELEVATOR_HEIGHT = 0.0794 + 0.09;
     public static final double PRE_L3_ARM_ANGLE = 1.2502;// + Math.PI * 3.0 / 180.0;
     public static final double PRE_L3_CORAL_WHEELS_VOLTAGE = 0;
     public static final double PRE_L3_ALGAE_WHEELS_VOLTAGE = 3;
 
     // L3 Constants TODO
-    public static final double L3_ELEVATOR_HEIGHT = 0.0794 + 0.04;
+    public static final double L3_ELEVATOR_HEIGHT = 0.0794 + 0.09;
     public static final double L3_ARM_ANGLE = 1.2502;// + Math.PI * 3.0 / 180.0;
     public static final double L3_CORAL_WHEELS_VOLTAGE = 7;
     public static final double L3_ALGAE_WHEELS_VOLTAGE = 3;
 
     // POST L3 Constants TODO
-    public static final double POST_L3_ELEVATOR_HEIGHT = 0.0794 + 0.04;
+    public static final double POST_L3_ELEVATOR_HEIGHT = 0.0794 + 0.0;
     public static final double POST_L3_ARM_ANGLE = 1.2502;// + Math.PI * 3.0 / 180.0;
     public static final double POST_L3_CORAL_WHEELS_VOLTAGE = 5;
     public static final double POST_L3_ALGAE_WHEELS_VOLTAGE = 3;
@@ -124,13 +124,11 @@ public class Constants {
     public static final double PROCESSOR_CORAL_WHEELS_VOLTAGE = 0;
     public static final double PROCESSOR_ALGAE_WHEELS_VOLTAGE = -1;
 
-    //POST PROCESSOR Constants TODO
     public static final double POST_PROCESSOR_ELEVATOR_HEIGHT = 0.261;
     public static final double POST_PROCESSOR_ARM_ANGLE = -1.3897;
     public static final double POST_PROCESSOR_CORAL_WHEELS_VOLTAGE = 0;
     public static final double POST_PROCESSOR_ALGAE_WHEELS_VOLTAGE = -1;
 
-    //EJECT Coral Constants TODO
     public static final double EJECT_CORAL_ELEVATOR_HEIGHT = 0;
     public static final double EJECT_CORAL_ARM_ANGLE = 0;
     public static final double EJECT_CORAL_CORAL_WHEELS_VOLTAGE = 0;
@@ -146,7 +144,7 @@ public class Constants {
     public static final double DEFAULT_ELEVATOR_HEIGHT = 0;
     public static final double DEFAULT_ARM_ANGLE = -1.5063691337036997;
     public static final double DEFAULT_CORAL_WHEELS_VOLTAGE = -0.1;
-    public static final double DEFAULT_ALGAE_WHEELS_VOLTAGE = 0;
+    public static final double DEFAULT_ALGAE_WHEELS_VOLTAGE = 3;
 
     //Algae Default Constants TODO
     public static final double ALGAE_DEFAULT_ELEVATOR_HEIGHT = 0;

--- a/src/main/java/frc/robot/superstructure/Constants.java
+++ b/src/main/java/frc/robot/superstructure/Constants.java
@@ -12,19 +12,19 @@ public class Constants {
 
     // PRE L1 Constants TODO
     public static final double PRE_L1_ELEVATOR_HEIGHT = 0;
-    public static final double PRE_L1_ARM_ANGLE = -1.608582730249298;
+    public static final double PRE_L1_ARM_ANGLE = -1.7;
     public static final double PRE_L1_CORAL_WHEELS_VOLTAGE = 0;
     public static final double PRE_L1_ALGAE_WHEELS_VOLTAGE = 3;
 
     // L1 Constants TODO
     public static final double L1_ELEVATOR_HEIGHT = 0;
-    public static final double L1_ARM_ANGLE = -1.608582730249298;
+    public static final double L1_ARM_ANGLE = -1.7;
     public static final double L1_CORAL_WHEELS_VOLTAGE = 5;
     public static final double L1_ALGAE_WHEELS_VOLTAGE = 3;
 
     // POST L1 Constants TODO
     public static final double POST_L1_ELEVATOR_HEIGHT = 0;
-    public static final double POST_L1_ARM_ANGLE = -1.608582730249298;
+    public static final double POST_L1_ARM_ANGLE = -1.7;
     public static final double POST_L1_CORAL_WHEELS_VOLTAGE = 5;
     public static final double POST_L1_ALGAE_WHEELS_VOLTAGE = 3;
 
@@ -47,19 +47,19 @@ public class Constants {
     public static final double POST_L2_ALGAE_WHEELS_VOLTAGE = 3;
 
     // PRE L3 Constants TODO
-    public static final double PRE_L3_ELEVATOR_HEIGHT = 0.0794 + 0.09;
+    public static final double PRE_L3_ELEVATOR_HEIGHT = 0.0794 + 0.11;
     public static final double PRE_L3_ARM_ANGLE = 1.2502;// + Math.PI * 3.0 / 180.0;
     public static final double PRE_L3_CORAL_WHEELS_VOLTAGE = 0;
     public static final double PRE_L3_ALGAE_WHEELS_VOLTAGE = 3;
 
     // L3 Constants TODO
-    public static final double L3_ELEVATOR_HEIGHT = 0.0794 + 0.09;
+    public static final double L3_ELEVATOR_HEIGHT = 0.0794 + 0.11;
     public static final double L3_ARM_ANGLE = 1.2502;// + Math.PI * 3.0 / 180.0;
     public static final double L3_CORAL_WHEELS_VOLTAGE = 7;
     public static final double L3_ALGAE_WHEELS_VOLTAGE = 3;
 
     // POST L3 Constants TODO
-    public static final double POST_L3_ELEVATOR_HEIGHT = 0.0794 + 0.0;
+    public static final double POST_L3_ELEVATOR_HEIGHT = 0.0794 + 0.11;
     public static final double POST_L3_ARM_ANGLE = 1.2502;// + Math.PI * 3.0 / 180.0;
     public static final double POST_L3_CORAL_WHEELS_VOLTAGE = 5;
     public static final double POST_L3_ALGAE_WHEELS_VOLTAGE = 3;

--- a/src/main/java/frc/robot/superstructure/Superstructure.java
+++ b/src/main/java/frc/robot/superstructure/Superstructure.java
@@ -334,7 +334,7 @@ public class Superstructure implements Logged {
         } else if (currentState().equals("PRE_NET") || currentState().equals("NET") || currentState().equals("POST_NET")) {
             return "Scoring Net";
         }
-        return "Disabled";
+        return "Travel";
     }
 
     public Trigger hasAlgaeTrigger() {


### PR DESCRIPTION
This pull request includes significant updates to the `elastic-layout.json` configuration and several Java classes to enhance the robot's automation and camera functionalities. The most important changes are grouped into layout adjustments, camera enhancements, and automation improvements.

### Layout Adjustments:
* Changed `field_rotation` from `90.0` to `-90.0` in `elastic-layout.json`.
* Renamed and resized various layout elements, such as changing "Match Time" to "match time" and adjusting dimensions. [[1]](diffhunk://#diff-294f0d40dd3f73e84a093f517037a30636d74fa844db10d94225279ad1d83c4cL65-R68) [[2]](diffhunk://#diff-294f0d40dd3f73e84a093f517037a30636d74fa844db10d94225279ad1d83c4cL81-R81)
* Added new elements like `autoChooser` and `getTagTimer` with specific properties and dimensions. [[1]](diffhunk://#diff-294f0d40dd3f73e84a093f517037a30636d74fa844db10d94225279ad1d83c4cL193-R252) [[2]](diffhunk://#diff-294f0d40dd3f73e84a093f517037a30636d74fa844db10d94225279ad1d83c4cL223-L235)

### Camera Enhancements:
* Implemented `Logged` interface in `PhotonAprilTagsCamera` and added new fields like `tagTimer` and `seenTrigger`. [[1]](diffhunk://#diff-c904231f30fd33e8fb983275b64d79a54b55b3ab0949ea78b9f02c189efee604L19-R24) [[2]](diffhunk://#diff-c904231f30fd33e8fb983275b64d79a54b55b3ab0949ea78b9f02c189efee604R33-R47)
* Updated `getEstimatedGlobalPose` to reset `tagTimer` when a valid target is detected.
* Added methods `getTagTimer` and `getTagTimerHigh` for logging purposes.

### Automation Improvements:
* Re-enabled and updated `initAutoChooser` in `RobotContainer` to include new auto modes and commands. [[1]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525L57-R65) [[2]](diffhunk://#diff-789275cb88dd16cec774f646d9a1711e27f068723fbaa996d4c3c37f9725d525R184-R201)
* Enhanced command sequences in `Automations` to include new logic for handling net poses and algae intake. [[1]](diffhunk://#diff-1efcee6a62039634fc860e58c79e129285ecd7a24b8bb535bf88fcd2883bd2a3R51-R76) [[2]](diffhunk://#diff-1efcee6a62039634fc860e58c79e129285ecd7a24b8bb535bf88fcd2883bd2a3L70-L85)
* Added new triggers and methods to manage automation states and poses more effectively.